### PR TITLE
Add password reset support

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
-from .models import Address # , UserProfile
+from django.contrib.auth.forms import PasswordResetForm
+from .models import Address  # , UserProfile
 
 User = get_user_model()
 
@@ -42,6 +43,23 @@ class AddressSerializer(serializers.ModelSerializer):
         model = Address
         fields = '__all__'
         read_only_fields = ('user',) # User will be set from request
+
+
+class PasswordResetSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+    def validate_email(self, value):
+        User = get_user_model()
+        if not User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("No user is associated with this email address.")
+        return value
+
+    def save(self, request=None):
+        form = PasswordResetForm({"email": self.validated_data["email"]})
+        if form.is_valid():
+            form.save(request=request, use_https=request.is_secure() if request else False,
+                      email_template_name="registration/password_reset_email.html")
+        return True
 
 # class UserProfileSerializer(serializers.ModelSerializer):
 #     class Meta:

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import RegisterView, UserDetailView, AddressViewSet
+from .views import RegisterView, UserDetailView, AddressViewSet, PasswordResetView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView # Uncomment this
 
 router = DefaultRouter()
@@ -9,6 +9,7 @@ router.register(r'addresses', AddressViewSet, basename='address')
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='auth_register'),
     path('user/', UserDetailView.as_view(), name='user_detail'),
+    path('password-reset/', PasswordResetView.as_view(), name='password_reset'),
 
     # If using JWT for token authentication:
     path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),   # Uncomment this

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -2,7 +2,12 @@ from rest_framework import generics, permissions, viewsets
 from rest_framework.response import Response
 # from rest_framework_simplejwt.tokens import RefreshToken # If using JWT for auth
 from django.contrib.auth import get_user_model
-from .serializers import UserSerializer, RegisterSerializer, AddressSerializer #, UserProfileSerializer
+from .serializers import (
+    UserSerializer,
+    RegisterSerializer,
+    AddressSerializer,
+    PasswordResetSerializer,
+)
 from .models import Address #, UserProfile
 
 User = get_user_model()
@@ -29,6 +34,17 @@ class AddressViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
+
+
+class PasswordResetView(generics.CreateAPIView):
+    serializer_class = PasswordResetSerializer
+    permission_classes = [permissions.AllowAny]
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(request=request)
+        return Response({"detail": "Password reset instructions sent if the email exists."})
 
 # class UserProfileViewSet(viewsets.ModelViewSet):
 #     serializer_class = UserProfileSerializer

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -158,4 +158,9 @@ MEDIA_ROOT = BASE_DIR / 'media'  # BASE_DIR is usually defined at the top of set
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Development email backend
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 # backend/your_project_name/settings.py
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -52,24 +52,3 @@ whitenoise>=6.0,<7.0
 # django-phonenumber-field>=7.0,<8.0 # For phone number validation and formatting
 # django-money>=2.2,<3.1 # For handling monetary values
 # django-mptt>=0.14,<0.16 # For tree-like structures (e.g., nested categories, if more complex than self-referential FK)
-```
-
-**Key Additions and Considerations:**
-
-* **`djangorestframework-simplejwt`**: Included directly for token-based authentication.
-* **`python-decouple`**: For managing environment variables (highly recommended).
-* **`psycopg2-binary`**: For PostgreSQL, a robust production database.
-* **`drf-yasg` / `drf-spectacular`**: For generating API documentation (Swagger/OpenAPI). Choose one. `drf-spectacular` is generally more modern.
-* **Celery & related packages**: For handling background tasks (e.g., sending confirmation emails, processing large data imports, etc.) asynchronously. `redis` is a common message broker for Celery.
-* **`django-imagekit`**: If you need more advanced image processing (like automatic thumbnail generation, watermarking) beyond what Pillow and simple model fields offer.
-* **Elasticsearch packages**: If you plan to implement a powerful search functionality using Elasticsearch.
-* **`stripe`**: Example for payment gateway integration. Replace/add based on your chosen provider(s).
-* **`gunicorn` & `whitenoise`**: Standard for production deployment.
-* **Testing libraries**: `coverage`, `factory-boy`, `pytest`, `pytest-django`, `pytest-cov` are very common for a robust testing setup.
-* **`django-ckeditor`**: If you need a rich text editor for product descriptions or a blog section within Django admin.
-* **Other Utilities**:
-    * `django-phonenumber-field`: For handling phone numbers.
-    * `django-money`: For accurately representing and working with monetary values.
-    * `django-mptt`: Useful for managing hierarchical data like deeply nested categories if the self-referential foreign key becomes cumbersome.
-
-Remember to uncomment the lines for the packages you decide to use. This list provides a strong foundation for most e-commerce backend nee

--- a/frontend/src/components/Auth/PasswordReset/index.tsx
+++ b/frontend/src/components/Auth/PasswordReset/index.tsx
@@ -3,6 +3,7 @@ import Breadcrumb from "@/components/Common/Breadcrumb";
 import Link from "next/link";
 import React, { useState } from "react";
 import { toast } from "react-toastify";
+import { requestPasswordReset } from "@/lib/apiService";
 
 const PasswordReset = () => {
   const [email, setEmail] = useState("");
@@ -22,7 +23,7 @@ const PasswordReset = () => {
 
     setIsSubmitting(true);
     try {
-      // TODO: integrate with password reset API
+      await requestPasswordReset(email);
       toast.success("If an account exists for this email, a reset link has been sent.");
       setEmail("");
     } catch (err: any) {

--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -258,6 +258,13 @@ export const changePassword = (passwordData: ChangePasswordData): Promise<any> =
     });
 };
 
+export const requestPasswordReset = (email: string): Promise<void> => {
+  return fetchWrapper<void>(`${ACCOUNTS_BASE_URL}/password-reset/`, {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  });
+};
+
 
 export const getUserAddresses = (): Promise<Address[]> => {
   return fetchWrapper<PaginatedResponse<Address>>(`${ACCOUNTS_BASE_URL}/addresses/`)


### PR DESCRIPTION
## Summary
- clean requirements.txt trailing notes
- add password reset serializer, view and route in Django backend
- enable console email backend for development
- expose password reset API on frontend
- update password reset page to call API

## Testing
- `npm run lint` *(fails: next not found)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*