### PR TITLE
Enable running on local network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Local Network Development
+
+This project contains a Django backend and a Next.js frontend.
+
+## Backend
+1. Install dependencies:
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. Run the development server so it is reachable from other devices:
+   ```bash
+   python backend/manage.py runserver 0.0.0.0:8000
+   ```
+   The server will listen on port `8000` on all network interfaces.
+
+## Frontend
+1. Install dependencies:
+   ```bash
+   cd frontend && npm install
+   ```
+2. Ensure the frontend knows how to reach the backend when accessed from another device.
+   Create a `frontend/.env.local` file and set the backend URL using your computer's IP address:
+   ```bash
+   NEXT_PUBLIC_API_BASE_URL=http://<YOUR_IP>:8000/api
+   NEXT_PUBLIC_DJANGO_API_URL=http://<YOUR_IP>:8000/api
+   ```
+3. Start the Next.js dev server:
+   ```bash
+   npm run dev
+   ```
+   This runs `next dev -H 0.0.0.0 -p 3000`, so the frontend is available on port `3000` from other devices on the network.
+
+Both the frontend and backend will now be accessible from devices connected to the same network (for example, via a phone hotspot).

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -24,7 +24,9 @@ SECRET_KEY = 'django-insecure--q56@mk$%ov5u8so)8-hlpf1jbkrjwj)cxue4!9lm@94$9sm1!
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
+# Allow all hosts during local development so the server is reachable from other
+# devices on the network.  Remember to restrict this in production.
 
 # Application definition
 
@@ -77,13 +79,10 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 10  # Default number of items per page
 }
 
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:3000",  # Your Next.js development server
-    "http://127.0.0.1:3000",
-    # Add your production frontend URL here
-]
-# Or, for more permissive settings during development (not recommended for production):
-# CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_ALL_ORIGINS = True
+# During local development it can be helpful to allow CORS requests from any
+# origin, especially when testing from another device on the same network.  In
+# production you should configure specific origins instead.
 
 TEMPLATES = [
     {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -H 0.0.0.0 -p 3000",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -H 0.0.0.0 -p 3000",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- allow all hosts & CORS in Django settings
- start Next.js dev server on 0.0.0.0:3000
- document how to run backend & frontend on local network

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: Missing script: "test")*