### PR TITLE
Fix README env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ This project contains a Django backend and a Next.js frontend.
    ```bash
    cd frontend && npm install
    ```
-2. Ensure the frontend knows how to reach the backend when accessed from another device.
+2. Ensure the frontend can reach the backend when accessed from another device.
    Create a `frontend/.env.local` file and set the backend URL using your computer's IP address:
    ```bash
    NEXT_PUBLIC_API_BASE_URL=http://<YOUR_IP>:8000/api
-   NEXT_PUBLIC_DJANGO_API_URL=http://<YOUR_IP>:8000/api
    ```
 3. Start the Next.js dev server:
    ```bash

--- a/frontend/src/components/Common/APITestComponent.tsx
+++ b/frontend/src/components/Common/APITestComponent.tsx
@@ -16,12 +16,12 @@ const APITestComponent = () => {
   const [isLoadingProducts, setIsLoadingProducts] = useState(true);
 
   useEffect(() => {
-    console.log("API_BASE_URL from env:", process.env.NEXT_PUBLIC_DJANGO_API_URL);
+    console.log("API_BASE_URL from env:", process.env.NEXT_PUBLIC_API_BASE_URL);
 
     const getCategories = async () => {
       setIsLoadingCategories(true);
       setCategoryError(null);
-      const categoriesUrl = `${process.env.NEXT_PUBLIC_DJANGO_API_URL || 'http://127.0.0.1:8000/api'}/shop/categories/?limit=100`;
+      const categoriesUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000/api'}/shop/categories/?limit=100`;
       console.log("Attempting to fetch categories from URL:", categoriesUrl);
       try {
         const response = await fetch(categoriesUrl);
@@ -58,7 +58,7 @@ const APITestComponent = () => {
     const getProducts = async () => {
       setIsLoadingProducts(true);
       setProductError(null);
-      const productsUrl = `${process.env.NEXT_PUBLIC_DJANGO_API_URL || 'http://127.0.0.1:8000/api'}/shop/products/`;
+      const productsUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000/api'}/shop/products/`;
       console.log("Attempting to fetch products from URL:", productsUrl);
       try {
         const response = await fetch(productsUrl);
@@ -99,7 +99,7 @@ const APITestComponent = () => {
   return (
     <div style={{ padding: '20px', border: '1px solid #ccc', margin: '20px', backgroundColor: '#f9f9f9' }}>
       <h2>API Connection Test Component</h2>
-      <p><strong>API Base URL (from env):</strong> {process.env.NEXT_PUBLIC_DJANGO_API_URL || 'Not Set - Using default http://127.0.0.1:8000/api'}</p>
+      <p><strong>API Base URL (from env):</strong> {process.env.NEXT_PUBLIC_API_BASE_URL || 'Not Set - Using default http://127.0.0.1:8000/api'}</p>
 
       <div style={{ marginTop: '15px', padding: '10px', border: '1px dashed #aaa' }}>
         <h3>Categories Status:</h3>


### PR DESCRIPTION
## Summary
- remove extra variable name from README and clarify instructions
- use `NEXT_PUBLIC_API_BASE_URL` throughout APITestComponent

## Testing
- `npm run lint` *(fails: next not found)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*