### PR TITLE
Fix cart persistence after login

### DIFF
--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -21,6 +21,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 import { store } from "@/redux/store"; // Import the store
 import { loadUserFromStorage } from "@/redux/features/auth-slice"; // Import the action
+import CartInitializer from "@/components/Common/CartInitializer";
 
 export default function RootLayout({
   children,
@@ -43,6 +44,7 @@ export default function RootLayout({
         ) : (
           <>
             <ReduxProvider> {/* ReduxProvider wraps everything */}
+              <CartInitializer />
               <CartModalProvider>
                 <QuickViewModalProvider>
                   <PreviewSliderProvider>

--- a/frontend/src/components/Common/CartInitializer.tsx
+++ b/frontend/src/components/Common/CartInitializer.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useEffect } from "react";
+import { useAppDispatch, useAppSelector } from "@/redux/store";
+import { setCartItems } from "@/redux/features/cart-slice";
+import { getCart } from "@/lib/apiService";
+
+const CartInitializer = () => {
+  const { isAuthenticated } = useAppSelector((state) => state.authReducer);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const fetchCart = async () => {
+      try {
+        const apiItems = await getCart();
+        const mapped = apiItems.map((item) => ({
+          id: item.product_details.id,
+          title: item.product_details.name,
+          price: Number(item.product_details.price),
+          discountedPrice: item.product_details.discounted_price
+            ? Number(item.product_details.discounted_price)
+            : Number(item.product_details.price),
+          quantity: item.quantity,
+          imgs: item.product_details.imgs,
+        }));
+        dispatch(setCartItems(mapped));
+      } catch (err) {
+        console.error("Failed to load cart", err);
+      }
+    };
+
+    if (isAuthenticated) {
+      fetchCart();
+    }
+  }, [isAuthenticated, dispatch]);
+
+  return null;
+};
+
+export default CartInitializer;


### PR DESCRIPTION
## Summary
- load cart items from the backend whenever a user becomes authenticated
- integrate cart loading inside the app layout so cart items display after login

## Testing
- `npm test` *(fails: Missing script)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*