### PR TITLE
Improve shop UI and price filter

### DIFF
--- a/frontend/src/components/Home/Hero/index.tsx
+++ b/frontend/src/components/Home/Hero/index.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 
 const Hero = () => {
   return (
-    <section className="overflow-hidden pb-10 lg:pb-12.5 xl:pb-15 pt-57.5 sm:pt-45 lg:pt-30 xl:pt-51.5 bg-[#E5EAF4]">
+    <section className="overflow-hidden pb-10 lg:pb-12.5 xl:pb-15 pt-57.5 sm:pt-45 lg:pt-30 xl:pt-51.5 bg-gradient-to-r from-blue-50 to-purple-50">
       <div className="max-w-[1170px] w-full mx-auto px-4 sm:px-8 xl:px-0">
         <div className="flex flex-wrap gap-5">
           <div className="xl:max-w-[757px] w-full">

--- a/frontend/src/components/ShopWithSidebar/PriceDropdown.tsx
+++ b/frontend/src/components/ShopWithSidebar/PriceDropdown.tsx
@@ -12,7 +12,7 @@ interface PriceDropdownProps {
   initialMax?: number;
 }
 
-const PriceDropdown = ({ onPriceChange, initialMin = 0, initialMax = 1000 }: PriceDropdownProps) => {
+const PriceDropdown = ({ onPriceChange, initialMin = 0, initialMax = 50 }: PriceDropdownProps) => {
   const [toggleDropdown, setToggleDropdown] = useState(true); // Keep it open by default or manage as needed
   const [priceRange, setPriceRange] = useState<[number, number]>([initialMin, initialMax]);
   const [minPriceInput, setMinPriceInput] = useState<string>(initialMin.toString());
@@ -119,8 +119,8 @@ const PriceDropdown = ({ onPriceChange, initialMin = 0, initialMax = 1000 }: Pri
           <RangeSlider
             id="price-range-slider"
             min={0} // Absolute minimum
-            max={1000} // Absolute maximum, adjust as needed
-            step={10}
+            max={50} // Absolute maximum
+            step={1}
             value={priceRange}
             onInput={handleSliderChange} // Use onInput for continuous updates or onChange for on release
             className="h-2.5 w-full"
@@ -148,7 +148,7 @@ const PriceDropdown = ({ onPriceChange, initialMin = 0, initialMax = 1000 }: Pri
                 onBlur={handleApplyFilter} // Apply on blur
                 className="w-20 rounded border border-gray-300 px-2 py-1 text-sm text-dark focus:border-blue focus:outline-none"
                 min={initialMin} // Set min for input field
-                max="1000" // Absolute max
+                max={initialMax} // Absolute max
               />
             </div>
           </div>

--- a/frontend/src/components/ShopWithSidebar/index.tsx
+++ b/frontend/src/components/ShopWithSidebar/index.tsx
@@ -8,8 +8,6 @@ import SingleGridItem from "../Shop/SingleGridItem";
 import SingleListItem from "../Shop/SingleListItem";
 import CategoryDropdown from "./CategoryDropdown";
 import PriceDropdown from "./PriceDropdown";
-import SizeDropdown from "./SizeDropdown";
-import ColorsDropdown from "./ColorsDropdwon";
 import GenderDropdown from "./GenderDropdown"; // Assuming this is for Brands
 import { getProducts, GetProductsParams, PaginatedResponse, getCategories } from "@/lib/apiService";
 import { LayoutGrid, List } from "lucide-react";
@@ -46,11 +44,9 @@ const ShopWithSidebarContent: React.FC = () => {
   const [filters, setFilters] = useState<Omit<GetProductsParams, 'page' | 'page_size'>>({
     ordering: "-created_at",
     category__slug: undefined,
-    min_price: undefined,
-    max_price: undefined,
+    min_price: 0,
+    max_price: 50,
     brand__slug: undefined,
-    color: undefined,
-    size: undefined,
     search: undefined,
   });
   // Flag to indicate if the initial filters from URL have been applied
@@ -143,15 +139,6 @@ const ShopWithSidebarContent: React.FC = () => {
     setCurrentPage(1);
   };
 
-  const handleSizeChange = (size: string | null) => {
-    setFilters(prev => ({...prev, size: size || undefined }));
-    setCurrentPage(1);
-  };
-
-  const handleColorChange = (color: string | null) => {
-    setFilters(prev => ({...prev, color: color || undefined }));
-    setCurrentPage(1);
-  };
 
   const handleBrandSlugChange = (brandSlug: string | null) => {
     setFilters(prev => ({...prev, brand__slug: brandSlug || undefined }));
@@ -164,8 +151,6 @@ const ShopWithSidebarContent: React.FC = () => {
     }
   };
 
-  const uniqueColors = Array.from(new Set(products.flatMap(p => p.variants?.flatMap(v => v.attributes.filter(a => a.attribute.toLowerCase() === 'color').map(a => a.value)) || (p.color ? [p.color] : [])))).filter(Boolean) as string[];
-  const uniqueSizes = Array.from(new Set(products.flatMap(p => p.variants?.flatMap(v => v.attributes.filter(a => a.attribute.toLowerCase() === 'size').map(a => a.value)) || (p.size ? [p.size] : [])))).filter(Boolean) as string[];
   const uniqueBrandNames = Array.from(new Set(products.map(p => p.brand_details?.name).filter(Boolean))) as string[];
 
   const renderPagination = () => { /* ... keep your existing pagination logic ... */
@@ -197,8 +182,6 @@ const ShopWithSidebarContent: React.FC = () => {
               <div className="space-y-6">
                 <CategoryDropdown allCategories={allCategories} isLoading={isLoadingCategories} error={categoryError} onCategoryChange={handleCategoryChange} selectedCategory={filters.category__slug} />
                 <PriceDropdown onPriceChange={handlePriceChange} initialMin={filters.min_price} initialMax={filters.max_price} />
-                <ColorsDropdown availableColors={uniqueColors} onColorChange={handleColorChange} selectedColor={filters.color}/>
-                <SizeDropdown availableSizes={uniqueSizes} onSizeChange={handleSizeChange} selectedSize={filters.size}/>
                 <GenderDropdown availableBrands={uniqueBrandNames} onBrandChange={handleBrandSlugChange} selectedBrand={filters.brand__slug} isLoading={isLoading} />
               </div>
             </aside>

--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -120,8 +120,6 @@ export interface GetProductsParams {
   min_price?: number;
   max_price?: number;
   brand__slug?: string;
-  color?: string;
-  size?: string;
   search?: string;
   ordering?: string;
   page?: number;
@@ -132,8 +130,14 @@ export const getProducts = (params?: GetProductsParams): Promise<PaginatedProduc
   const queryParams = new URLSearchParams();
   if (params) {
     Object.entries(params).forEach(([key, value]) => {
-      if (value !== undefined && value !== null && value !== '') { // Ensure empty strings are not appended
-        queryParams.append(key, String(value));
+      if (value !== undefined && value !== null && value !== '') {
+        if (key === 'min_price') {
+          queryParams.append('price__gte', String(value));
+        } else if (key === 'max_price') {
+          queryParams.append('price__lte', String(value));
+        } else {
+          queryParams.append(key, String(value));
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- tweak hero background gradient for nicer look
- simplify shop sidebar filters
- fix price range filter and limit slider to $0–$50
- map price filter to backend query params

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `pytest` *(fails: command not found)*