### PR TITLE
Improve responsive home UI and hide prices for guests

### DIFF
--- a/frontend/src/components/Common/QuickViewModal.tsx
+++ b/frontend/src/components/Common/QuickViewModal.tsx
@@ -265,12 +265,28 @@ const QuickViewModal = () => {
             </div>
 
             <p className="mb-3 text-lg font-semibold">
-              <span className={`${(currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice) ? 'text-red-500' : 'text-primary'}`}>
-                 ${effectivePrice.toFixed(2)}
-              </span>
-              {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
-                <span className="ml-2 text-base text-body-color line-through dark:text-dark-6">
-                  ${currentPrice.toFixed(2)}
+              {isAuthenticated ? (
+                <>
+                  <span
+                    className={`${
+                      currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice
+                        ? 'text-red-500'
+                        : 'text-primary'
+                    }`}
+                  >
+                     ${effectivePrice.toFixed(2)}
+                  </span>
+                  {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
+                    <span className="ml-2 text-base text-body-color line-through dark:text-dark-6">
+                      ${currentPrice.toFixed(2)}
+                    </span>
+                  )}
+                </>
+              ) : (
+                <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded">
+                  {product.get_discount_percentage && product.get_discount_percentage > 0
+                    ? `${product.get_discount_percentage}% OFF`
+                    : 'Login to see price'}
                 </span>
               )}
             </p>

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -252,8 +252,8 @@ const Header = () => {
       <div className="border-t border-gray-200">
         <div className="max-w-[1170px] mx-auto px-4 sm:px-7.5 xl:px-0">
           <div className="flex items-center justify-between">
-            <nav className="hidden xl:flex">
-              <ul className="flex items-center gap-x-8">
+            <nav className="hidden xl:flex overflow-x-auto scrollbar-none">
+              <ul className="flex items-center gap-x-6 xl:gap-x-8">
                 {headerMenuData.map((menuItem, i) => (
                   menuItem.submenu ? (
                     <Dropdown key={i} item={menuItem} stickyMenu={stickyMenu} openSubMenu={openSubMenu} handleSubMenuToggle={handleSubMenuToggle} />

--- a/frontend/src/components/Home/Hero/index.tsx
+++ b/frontend/src/components/Home/Hero/index.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import HeroCarousel from "./HeroCarousel";
 import HeroFeature from "./HeroFeature";
 import Image from "next/image";
+import { useAppSelector } from "@/redux/store";
 
 const Hero = () => {
+  const isAuthenticated = useAppSelector((state) => state.authReducer.isAuthenticated);
   return (
     <section className="overflow-hidden pb-10 lg:pb-12.5 xl:pb-15 pt-57.5 sm:pt-45 lg:pt-30 xl:pt-51.5 bg-gradient-to-r from-blue-50 to-purple-50">
       <div className="max-w-[1170px] w-full mx-auto px-4 sm:px-8 xl:px-0">
@@ -37,12 +39,20 @@ const Hero = () => {
                         limited time offer
                       </p>
                       <span className="flex items-center gap-3">
-                        <span className="font-medium text-heading-5 text-red">
-                          $699
-                        </span>
-                        <span className="font-medium text-2xl text-dark-4 line-through">
-                          $999
-                        </span>
+                        {isAuthenticated ? (
+                          <>
+                            <span className="font-medium text-heading-5 text-red">
+                              $699
+                            </span>
+                            <span className="font-medium text-2xl text-dark-4 line-through">
+                              $999
+                            </span>
+                          </>
+                        ) : (
+                          <span className="font-medium text-heading-5 text-red-600 bg-red-50 px-2 py-1 rounded">
+                            30% OFF
+                          </span>
+                        )}
                       </span>
                     </div>
                   </div>
@@ -69,12 +79,20 @@ const Hero = () => {
                         limited time offer
                       </p>
                       <span className="flex items-center gap-3">
-                        <span className="font-medium text-heading-5 text-red">
-                          $699
-                        </span>
-                        <span className="font-medium text-2xl text-dark-4 line-through">
-                          $999
-                        </span>
+                        {isAuthenticated ? (
+                          <>
+                            <span className="font-medium text-heading-5 text-red">
+                              $699
+                            </span>
+                            <span className="font-medium text-2xl text-dark-4 line-through">
+                              $999
+                            </span>
+                          </>
+                        ) : (
+                          <span className="font-medium text-heading-5 text-red-600 bg-red-50 px-2 py-1 rounded">
+                            30% OFF
+                          </span>
+                        )}
                       </span>
                     </div>
                   </div>

--- a/frontend/src/components/Shop/SingleGridItem.tsx
+++ b/frontend/src/components/Shop/SingleGridItem.tsx
@@ -199,15 +199,29 @@ const SingleGridItem = ({ product: item }: { product: Product }) => {
           </Link>
         </h3>
         <div className="mt-auto">
-          <span className="flex items-center gap-2 font-semibold text-base">
-            <span className={`${currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice ? 'text-red-600' : 'text-dark'}`}>
-              ${effectivePrice.toFixed(2)}
+          {isAuthenticated ? (
+            <span className="flex items-center gap-2 font-semibold text-base">
+              <span
+                className={`${
+                  currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice
+                    ? 'text-red-600'
+                    : 'text-dark'
+                }`}
+              >
+                ${effectivePrice.toFixed(2)}
+              </span>
+              {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
+                <span className="text-gray-500 line-through text-sm">${currentPrice.toFixed(2)}</span>
+              )}
             </span>
-            {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
-              <span className="text-gray-500 line-through text-sm">${currentPrice.toFixed(2)}</span>
-            )}
-          </span>
-           {!item.is_available && (
+          ) : (
+            <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded">
+              {item.get_discount_percentage && item.get_discount_percentage > 0
+                ? `${item.get_discount_percentage}% OFF`
+                : 'Login to see price'}
+            </span>
+          )}
+          {!item.is_available && (
             <p className="text-xs text-red-500 mt-1 font-medium">Out of Stock</p>
           )}
         </div>

--- a/frontend/src/components/Shop/SingleListItem.tsx
+++ b/frontend/src/components/Shop/SingleListItem.tsx
@@ -179,14 +179,28 @@ const SingleListItem = ({ item }: { item: Product }) => {
           </div>
 
           <div className="mt-auto">
-            <span className="flex items-center gap-2 font-semibold text-lg mb-3">
-              <span className={`${currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice ? 'text-red-600' : 'text-dark'}`}>
-                ${effectivePrice.toFixed(2)}
+            {isAuthenticated ? (
+              <span className="flex items-center gap-2 font-semibold text-lg mb-3">
+                <span
+                  className={`${
+                    currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice
+                      ? 'text-red-600'
+                      : 'text-dark'
+                  }`}
+                >
+                  ${effectivePrice.toFixed(2)}
+                </span>
+                {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
+                  <span className="text-gray-500 line-through text-base">${currentPrice.toFixed(2)}</span>
+                )}
               </span>
-              {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
-                <span className="text-gray-500 line-through text-base">${currentPrice.toFixed(2)}</span>
-              )}
-            </span>
+            ) : (
+              <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded mb-3">
+                {item.get_discount_percentage && item.get_discount_percentage > 0
+                  ? `${item.get_discount_percentage}% OFF`
+                  : 'Login to see price'}
+              </span>
+            )}
             {!item.is_available && (
                 <p className="text-xs text-red-500 mb-3 font-medium">Out of Stock</p>
             )}

--- a/frontend/src/components/ShopDetails/index.tsx
+++ b/frontend/src/components/ShopDetails/index.tsx
@@ -267,13 +267,29 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
               </div>
 
               <h3 className="font-semibold text-2xl sm:text-3xl mb-5">
-                <span className={`text-dark dark:text-white ${(product.discounted_price != null && Number(product.discounted_price) < Number(product.price)) ? 'text-red-500' : 'text-primary'}`}>
-                    ${effectivePrice.toFixed(2)}
-                </span>
-                {product.discounted_price != null && Number(product.discounted_price) < Number(product.price) && (
-                    <span className="ml-2 text-lg line-through text-gray-500 dark:text-dark-6">
-                    ${Number(product.price).toFixed(2)}
+                {isAuthenticated ? (
+                  <>
+                    <span
+                      className={`text-dark dark:text-white ${
+                        product.discounted_price != null && Number(product.discounted_price) < Number(product.price)
+                          ? 'text-red-500'
+                          : 'text-primary'
+                      }`}
+                    >
+                      ${effectivePrice.toFixed(2)}
                     </span>
+                    {product.discounted_price != null && Number(product.discounted_price) < Number(product.price) && (
+                      <span className="ml-2 text-lg line-through text-gray-500 dark:text-dark-6">
+                        ${Number(product.price).toFixed(2)}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded">
+                    {product.get_discount_percentage && product.get_discount_percentage > 0
+                      ? `${product.get_discount_percentage}% OFF`
+                      : 'Login to see price'}
+                  </span>
                 )}
               </h3>
 

--- a/frontend/src/components/Wishlist/SingleItem.tsx
+++ b/frontend/src/components/Wishlist/SingleItem.tsx
@@ -116,7 +116,7 @@ const SingleItem = ({ item, onRemoveSuccess }: { item: Product; onRemoveSuccess:
               <Link href={`/shop-details/${item.slug || item.id}`}> {item.name} </Link>
             </h3>
             {/* Display original price if there's a discount */}
-            {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
+            {isAuthenticated && currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
                 <p className="text-xs text-gray-500 dark:text-gray-400 line-through">${currentPrice.toFixed(2)}</p>
             )}
           </div>
@@ -125,7 +125,11 @@ const SingleItem = ({ item, onRemoveSuccess }: { item: Product; onRemoveSuccess:
 
       {/* Unit Price */}
       <div className="hidden sm:block sm:min-w-[150px] md:min-w-[180px] xl:min-w-[205px] px-2 text-center">
-        <p className="text-dark dark:text-white font-medium">${effectivePrice.toFixed(2)}</p>
+        {isAuthenticated ? (
+          <p className="text-dark dark:text-white font-medium">${effectivePrice.toFixed(2)}</p>
+        ) : (
+          <p className="font-semibold text-red-600">{item.get_discount_percentage && item.get_discount_percentage > 0 ? `${item.get_discount_percentage}% OFF` : 'Login to see price'}</p>
+        )}
       </div>
 
       {/* Stock Status */}


### PR DESCRIPTION
## Summary
- hide product pricing for unauthenticated users across the shop
- show discount percent instead of price for guests
- adjust hero section and demo banners to show discount when logged out
- tweak header navigation spacing for cleaner look

## Testing
- `npm run lint` *(fails: next not found)*