### PR TITLE
Show discount badge for all users

### DIFF
--- a/frontend/src/components/Common/DiscountBadge.tsx
+++ b/frontend/src/components/Common/DiscountBadge.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface DiscountBadgeProps {
+  percentage: number;
+  className?: string;
+}
+
+const DiscountBadge: React.FC<DiscountBadgeProps> = ({ percentage, className = '' }) => {
+  if (!percentage || percentage <= 0) return null;
+  return (
+    <span className={`inline-flex items-center font-semibold text-xs text-white bg-red rounded-full px-2 py-0.5 shadow ${className}`}>
+      {percentage}% OFF
+    </span>
+  );
+};
+
+export default DiscountBadge;

--- a/frontend/src/components/Common/ProductItem.tsx
+++ b/frontend/src/components/Common/ProductItem.tsx
@@ -15,6 +15,7 @@ import {
 import { toast } from "react-toastify";
 import Link from "next/link";
 import { Heart, Eye, ShoppingCart } from 'lucide-react';
+import DiscountBadge from "./DiscountBadge";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/250x250/F0F0F0/777777?text=No+Image";
 
@@ -154,9 +155,7 @@ const ProductItem = ({ item }: { item: Product }) => {
           />
         </Link>
         {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-          <span className="absolute top-3 right-3 bg-red-500 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
-            {item.get_discount_percentage}% OFF
-          </span>
+          <DiscountBadge percentage={item.get_discount_percentage} className="absolute top-3 right-3" />
         )}
         {!item.is_available && (
           <span className="absolute top-3 left-3 bg-gray-700 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
@@ -217,6 +216,9 @@ const ProductItem = ({ item }: { item: Product }) => {
             </span>
             {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
               <span className="text-gray-500 line-through text-sm">${currentPrice.toFixed(2)}</span>
+            )}
+            {item.get_discount_percentage && item.get_discount_percentage > 0 && (
+              <DiscountBadge percentage={item.get_discount_percentage} className="ml-1" />
             )}
           </span>
            {!item.is_available && (

--- a/frontend/src/components/Common/QuickViewModal.tsx
+++ b/frontend/src/components/Common/QuickViewModal.tsx
@@ -13,6 +13,7 @@ import { toast } from "react-toastify";
 import PreviewSlider from "./PreviewSlider"; // Assuming this component is correctly implemented
 import { getProductBySlug } from "@/lib/apiService";
 import { Star, Heart, ShoppingCart, XCircle, RefreshCw } from "lucide-react"; // Lucide icons
+import DiscountBadge from "@/components/Common/DiscountBadge";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/600x400/eee/ccc?text=No+Image";
 
@@ -280,6 +281,9 @@ const QuickViewModal = () => {
                     <span className="ml-2 text-base text-body-color line-through dark:text-dark-6">
                       ${currentPrice.toFixed(2)}
                     </span>
+                  )}
+                  {product.get_discount_percentage && product.get_discount_percentage > 0 && (
+                    <DiscountBadge percentage={product.get_discount_percentage} className="ml-2" />
                   )}
                 </>
               ) : (

--- a/frontend/src/components/Home/BestSeller/SingleItem.tsx
+++ b/frontend/src/components/Home/BestSeller/SingleItem.tsx
@@ -17,6 +17,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { toast } from "react-toastify"; // For user feedback
 import { Heart, Eye, ShoppingCart } from 'lucide-react'; // Lucide icons
+import DiscountBadge from "@/components/Common/DiscountBadge";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/280x280/F0F0F0/777777?text=Image+Not+Available";
 
@@ -145,9 +146,7 @@ const SingleItem = ({ item }: { item: Product }) => {
           />
         </Link>
         {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-          <span className="absolute top-3 right-3 bg-red-500 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
-            {item.get_discount_percentage}% OFF
-          </span>
+          <DiscountBadge percentage={item.get_discount_percentage} className="absolute top-3 right-3" />
         )}
          {!item.is_available && (
           <span className="absolute top-3 left-3 bg-gray-700 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
@@ -209,6 +208,9 @@ const SingleItem = ({ item }: { item: Product }) => {
             </span>
             {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
               <span className="text-gray-500 line-through text-sm">${currentPrice.toFixed(2)}</span>
+            )}
+            {item.get_discount_percentage && item.get_discount_percentage > 0 && (
+              <DiscountBadge percentage={item.get_discount_percentage} className="ml-1" />
             )}
           </span>
            {!item.is_available && (

--- a/frontend/src/components/Shop/SingleGridItem.tsx
+++ b/frontend/src/components/Shop/SingleGridItem.tsx
@@ -14,6 +14,7 @@ import {
 import { toast } from "react-toastify";
 import Link from "next/link";
 import { Heart, Eye, ShoppingCart } from 'lucide-react';
+import DiscountBadge from "@/components/Common/DiscountBadge";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/250x250/F0F0F0/777777?text=No+Image";
 
@@ -143,9 +144,7 @@ const SingleGridItem = ({ product: item }: { product: Product }) => {
           />
         </Link>
         {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-          <span className="absolute top-3 right-3 bg-red-500 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
-            {item.get_discount_percentage}% OFF
-          </span>
+          <DiscountBadge percentage={item.get_discount_percentage} className="absolute top-3 right-3" />
         )}
         {!item.is_available && (
           <span className="absolute top-3 left-3 bg-gray-700 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
@@ -212,6 +211,9 @@ const SingleGridItem = ({ product: item }: { product: Product }) => {
               </span>
               {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
                 <span className="text-gray-500 line-through text-sm">${currentPrice.toFixed(2)}</span>
+              )}
+              {item.get_discount_percentage && item.get_discount_percentage > 0 && (
+                <DiscountBadge percentage={item.get_discount_percentage} className="ml-1" />
               )}
             </span>
           ) : (

--- a/frontend/src/components/Shop/SingleListItem.tsx
+++ b/frontend/src/components/Shop/SingleListItem.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { toast } from "react-toastify"; // For user feedback
 import { Heart, Eye, ShoppingCart } from 'lucide-react'; // Lucide icons
+import DiscountBadge from "@/components/Common/DiscountBadge";
 
 const PLACEHOLDER_IMAGE_URL = "https://placehold.co/250x250/F0F0F0/777777?text=No+Image";
 
@@ -151,9 +152,7 @@ const SingleListItem = ({ item }: { item: Product }) => {
             />
           </Link>
            {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-            <span className="absolute top-3 right-3 bg-red-500 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
-                {item.get_discount_percentage}% OFF
-            </span>
+            <DiscountBadge percentage={item.get_discount_percentage} className="absolute top-3 right-3" />
             )}
             {!item.is_available && (
             <span className="absolute top-3 left-3 bg-gray-700 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
@@ -192,6 +191,9 @@ const SingleListItem = ({ item }: { item: Product }) => {
                 </span>
                 {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
                   <span className="text-gray-500 line-through text-base">${currentPrice.toFixed(2)}</span>
+                )}
+                {item.get_discount_percentage && item.get_discount_percentage > 0 && (
+                  <DiscountBadge percentage={item.get_discount_percentage} className="ml-1" />
                 )}
               </span>
             ) : (

--- a/frontend/src/components/ShopDetails/index.tsx
+++ b/frontend/src/components/ShopDetails/index.tsx
@@ -8,6 +8,7 @@ import RecentlyViewdItems from "./RecentlyViewd";
 import { usePreviewSlider } from "@/app/context/PreviewSliderContext";
 import { Product, ProductMediaItem } from "@/types/product";
 import { Star, Heart, ShoppingCart } from "lucide-react";
+import DiscountBadge from "@/components/Common/DiscountBadge";
 import { useDispatch } from "react-redux";
 import { AppDispatch, useAppSelector } from "@/redux/store";
 import { addItemToCart } from "@/redux/features/cart-slice";
@@ -243,9 +244,7 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
                   {product.name || "Product Name"}
                 </h2>
                 {product.get_discount_percentage != null && product.get_discount_percentage > 0 && (
-                    <div className="ml-2 inline-flex font-medium text-xs sm:text-custom-sm text-white bg-red-500 rounded py-0.5 px-2 sm:px-2.5 whitespace-nowrap">
-                        {product.get_discount_percentage.toFixed(0)}% OFF
-                    </div>
+                    <DiscountBadge percentage={product.get_discount_percentage} className="ml-2" />
                 )}
               </div>
 
@@ -282,6 +281,9 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
                       <span className="ml-2 text-lg line-through text-gray-500 dark:text-dark-6">
                         ${Number(product.price).toFixed(2)}
                       </span>
+                    )}
+                    {product.get_discount_percentage != null && product.get_discount_percentage > 0 && (
+                      <DiscountBadge percentage={product.get_discount_percentage} className="ml-2" />
                     )}
                   </>
                 ) : (

--- a/frontend/src/components/Wishlist/SingleItem.tsx
+++ b/frontend/src/components/Wishlist/SingleItem.tsx
@@ -8,6 +8,7 @@ import { addItemToCart } from "@/redux/features/cart-slice";
 import { removeFromWishlist as apiRemoveFromWishlist } from "@/lib/apiService";
 import Image from "next/image";
 import Link from "next/link";
+import DiscountBadge from "@/components/Common/DiscountBadge";
 import { toast } from 'react-toastify';
 // No need to import removeItemFromWishlistAction from Redux slice here if parent handles Redux state update
 
@@ -126,7 +127,12 @@ const SingleItem = ({ item, onRemoveSuccess }: { item: Product; onRemoveSuccess:
       {/* Unit Price */}
       <div className="hidden sm:block sm:min-w-[150px] md:min-w-[180px] xl:min-w-[205px] px-2 text-center">
         {isAuthenticated ? (
-          <p className="text-dark dark:text-white font-medium">${effectivePrice.toFixed(2)}</p>
+          <p className="text-dark dark:text-white font-medium flex items-center justify-center gap-1">
+            ${effectivePrice.toFixed(2)}
+            {item.get_discount_percentage && item.get_discount_percentage > 0 && (
+              <DiscountBadge percentage={item.get_discount_percentage} />
+            )}
+          </p>
         ) : (
           <p className="font-semibold text-red-600">{item.get_discount_percentage && item.get_discount_percentage > 0 ? `${item.get_discount_percentage}% OFF` : 'Login to see price'}</p>
         )}


### PR DESCRIPTION
## Summary
- add a reusable `DiscountBadge` component
- use `DiscountBadge` on product listings, bestseller items, shop list/grid items and product details
- show badge beside prices for authenticated users too

## Testing
- `npm --prefix frontend run lint` *(fails: `next` not found)*