### PR TITLE
Fix header text visibility and page padding

### DIFF
--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -49,7 +49,9 @@ export default function RootLayout({
                 <QuickViewModalProvider>
                   <PreviewSliderProvider>
                     <HeaderWithSuspense />
-                    {children}
+                    <main className="pt-20 md:pt-24">
+                      {children}
+                    </main>
                     <QuickViewModal />
                     <CartSidebarModal />
                     <PreviewSliderModal />

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -164,7 +164,10 @@ const Header = () => {
     >
       <div className={`max-w-[1170px] mx-auto px-4 sm:px-7.5 xl:px-0 ${stickyMenu ? "py-3 lg:py-3.5" : "py-4 lg:py-5"}`}> {/* Adjusted padding for sticky */}
         <div className="flex items-center justify-between gap-4">
-          <Link className="flex-shrink-0 text-3xl font-extrabold bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent hover:opacity-90 transition-opacity" href="/">
+          <Link
+            className="flex-shrink-0 text-3xl font-extrabold text-blue-600 hover:text-indigo-600 transition-colors"
+            href="/"
+          >
             {businessName}
           </Link>
 


### PR DESCRIPTION
## Summary
- ensure business name link uses solid color
- add top padding in layout so content doesn't hide behind header

## Testing
- `npm run lint` *(fails: next not found)*