### PR TITLE
Fix header overlap on large screens

### DIFF
--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
                 <QuickViewModalProvider>
                   <PreviewSliderProvider>
                     <HeaderWithSuspense />
-                    <main className="pt-20 md:pt-24">
+                    <main className="pt-20 md:pt-24 xl:pt-32">
                       {children}
                     </main>
                     <QuickViewModal />


### PR DESCRIPTION
## Summary
- avoid header covering page content by increasing main padding for xl screens

## Testing
- `npx --yes next lint --dir frontend` *(fails: connect EHOSTUNREACH)*
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*