### PR TITLE
Fix Tailwind font-sans class

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -12,6 +12,7 @@ const config: Config = {
   theme: {
     fontFamily: {
       "euclid-circular-a": ["Euclid Circular A"],
+      sans: ["Euclid Circular A", ...defaultTheme.fontFamily.sans],
     },
     container: {
       center: true,


### PR DESCRIPTION
## Summary
- define a `sans` font family in Tailwind config so `font-sans` works

## Testing
- `pytest`