### PR TITLE
Add services section and update tagline

### DIFF
--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -164,12 +164,15 @@ const Header = () => {
     >
       <div className={`max-w-[1170px] mx-auto px-4 sm:px-7.5 xl:px-0 ${stickyMenu ? "py-3 lg:py-3.5" : "py-4 lg:py-5"}`}> {/* Adjusted padding for sticky */}
         <div className="flex items-center justify-between gap-4">
-          <Link
-            className="flex-shrink-0 text-3xl font-extrabold text-accent hover:text-[#b88d4f] transition-colors"
-            href="/"
-          >
-            {businessName}
-          </Link>
+          <div className="flex flex-col leading-none">
+            <Link
+              className="flex-shrink-0 text-3xl font-extrabold text-accent hover:text-[#b88d4f] transition-colors"
+              href="/"
+            >
+              {businessName}
+            </Link>
+            <span className="text-xs text-gray-600">Since 2023</span>
+          </div>
 
           <div className="hidden lg:flex flex-grow max-w-[550px] w-full">
             <form onSubmit={handleSearchSubmit} className="w-full">

--- a/frontend/src/components/Home/Services/index.tsx
+++ b/frontend/src/components/Home/Services/index.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const Services = () => {
+  return (
+    <section className="py-20 bg-gray-50">
+      <div className="max-w-[1170px] w-full mx-auto px-4 sm:px-8 xl:px-0">
+        <h2 className="text-center font-bold text-2xl mb-8">Our Services</h2>
+        <ul className="grid gap-6 sm:grid-cols-3 text-center">
+          <li className="p-4 bg-white shadow rounded">Flatbed</li>
+          <li className="p-4 bg-white shadow rounded">Dryvan</li>
+          <li className="p-4 bg-white shadow rounded">Temperature Controlled</li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default Services;

--- a/frontend/src/components/Home/index.tsx
+++ b/frontend/src/components/Home/index.tsx
@@ -4,7 +4,7 @@ import Categories from "./Categories";
 import NewArrival from "./NewArrivals";
 import PromoBanner from "./PromoBanner";
 import BestSeller from "./BestSeller";
-import CounDown from "./Countdown";
+import Services from "./Services";
 import Testimonials from "./Testimonials";
 import Newsletter from "../Common/Newsletter";
 
@@ -16,7 +16,7 @@ const Home = () => {
       <NewArrival />
       <PromoBanner />
       <BestSeller />
-      <CounDown />
+      <Services />
       <Testimonials />
       <Newsletter />
     </main>


### PR DESCRIPTION
## Summary
- update header with new "Since 2023" tagline
- add a Services section listing Flatbed, Dryvan and Temperature Controlled offerings
- show the new Services section on the home page

## Testing
- `npm run lint` *(fails: `next` not found)*