### PR TITLE
Add profile image field

### DIFF
--- a/backend/accounts/migrations/0002_user_profile_image.py
+++ b/backend/accounts/migrations/0002_user_profile_image.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='profile_image',
+            field=models.ImageField(blank=True, null=True, upload_to='profile_images/'),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 class User(AbstractUser):
     email = models.EmailField(_('email address'), unique=True)
+    profile_image = models.ImageField(upload_to='profile_images/', blank=True, null=True)
 
     # Add or change related_name for groups and user_permissions
     # to avoid clashes with the default auth.User model.

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -6,9 +6,11 @@ from .models import Address  # , UserProfile
 User = get_user_model()
 
 class UserSerializer(serializers.ModelSerializer):
+    profile_image = serializers.ImageField(read_only=True)
+
     class Meta:
         model = User
-        fields = ('id', 'username', 'email', 'first_name', 'last_name', 'is_staff') # Add other fields as needed
+        fields = ('id', 'username', 'email', 'first_name', 'last_name', 'is_staff', 'profile_image')
         read_only_fields = ('is_staff',)
 
 class RegisterSerializer(serializers.ModelSerializer):

--- a/backend/testimonials/serializers.py
+++ b/backend/testimonials/serializers.py
@@ -18,6 +18,8 @@ class TestimonialSerializer(serializers.ModelSerializer):
             validated_data['user'] = request.user
             if not validated_data.get('author_name'):
                 validated_data['author_name'] = request.user.get_full_name() or request.user.username
+            if not validated_data.get('author_image') and getattr(request.user, 'profile_image', None):
+                validated_data['author_image'] = request.user.profile_image
         elif not validated_data.get('author_name'):
             raise serializers.ValidationError({'authorName': 'This field is required for guest testimonials.'})
         return super().create(validated_data)

--- a/frontend/src/components/Home/Testimonials/SingleItem.tsx
+++ b/frontend/src/components/Home/Testimonials/SingleItem.tsx
@@ -43,7 +43,7 @@ const SingleItem = ({ testimonial }: { testimonial: Testimonial }) => {
       <a href="#" className="flex items-center gap-4">
         <div className="w-12.5 h-12.5 rounded-full overflow-hidden">
           <Image
-            src={testimonial.authorImg}
+            src={testimonial.authorImg || "/images/users/user-04.jpg"}
             alt="author"
             className="w-12.5 h-12.5 rounded-full overflow-hidden"
             width={50}

--- a/frontend/src/components/MyAccount/index.tsx
+++ b/frontend/src/components/MyAccount/index.tsx
@@ -252,7 +252,7 @@ const handleLogout = () => {
             <div className="xl:w-1/4 bg-white dark:bg-dark shadow-lg rounded-xl p-6 self-start">
               <div className="flex items-center gap-4 mb-8 pb-6 border-b border-gray-200 dark:border-dark-3">
                 <Image
-                  src={"/images/users/user-04.jpg"} // Replace with dynamic user avatar if available
+                  src={authUser?.profile_image || "/images/users/user-04.jpg"}
                   alt={authUser?.username || "User"}
                   width={64}
                   height={64}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -6,6 +6,7 @@ export interface User {
   email: string;
   first_name?: string;
   last_name?: string;
+  profile_image?: string;
   // Add any other fields your UserSerializer exposes
 }
 


### PR DESCRIPTION
## Summary
- add `profile_image` to `User` model with a migration
- expose `profile_image` in serializers and user type
- fallback to the profile image when creating testimonials
- show user profile image in the account page and testimonials component

## Testing
- `pytest --maxfail=1 --disable-warnings` *(fails: no tests)*
- `python manage.py check` *(fails: Django not installed)*
- `npm run lint` *(fails: next not installed)*