### PR TITLE
Fix header dropdown overlay on desktop

### DIFF
--- a/frontend/src/components/Header/Dropdown.tsx
+++ b/frontend/src/components/Header/Dropdown.tsx
@@ -39,8 +39,8 @@ const Dropdown = ({
       <Link
         href={item.path || "#"}
         onClick={item.submenu && item.submenu.length > 0 ? onToggleSubMenu : undefined}
-        className={`hover:text-blue text-custom-sm font-medium text-dark flex items-center justify-between w-full xl:w-auto ${
-          stickyMenu ? "xl:py-4" : "xl:py-6"
+        className={`hover:text-blue text-custom-sm font-medium text-dark flex items-center justify-between w-full lg:w-auto ${
+          stickyMenu ? "lg:py-4" : "lg:py-6"
         } ${isSubMenuOpen ? "text-blue" : ""}`}
       >
         {item.title} {/* Safe to access item.title here */}
@@ -48,7 +48,7 @@ const Dropdown = ({
           <svg
             className={`ml-1.5 fill-current transition-transform duration-200 ease-in-out transform ${
               isSubMenuOpen ? "rotate-180" : "rotate-0"
-            } xl:group-hover:rotate-180`}
+            } lg:group-hover:rotate-180`}
             width="10"
             height="10"
             viewBox="0 0 10 10"
@@ -62,9 +62,9 @@ const Dropdown = ({
 
       {item.submenu && item.submenu.length > 0 && (
         <ul
-          className={`xl:absolute xl:left-0 xl:top-full xl:w-[220px] rounded-md bg-white xl:shadow-nav xl:py-2 static mt-2 pl-4 xl:pl-0 ${
+          className={`lg:absolute lg:left-0 lg:top-full lg:w-[220px] rounded-md bg-white lg:shadow-nav lg:py-2 static mt-2 pl-4 lg:pl-0 ${
             isSubMenuOpen ? 'block' : 'hidden'
-          } xl:hidden xl:group-hover:block`}
+          } lg:hidden lg:group-hover:block`}
         >
           {item.submenu.map((subItem, index) => {
             // Stricter check for subItem as well
@@ -76,7 +76,7 @@ const Dropdown = ({
               <li key={subItem.id || index}>
                 <Link
                   href={subItem.path || "#"}
-                  className="text-dark-4 hover:text-blue text-custom-sm font-medium block py-2.5 px-6 xl:px-4"
+                  className="text-dark-4 hover:text-blue text-custom-sm font-medium block py-2.5 px-6 lg:px-4"
                 >
                   {subItem.title}
                 </Link>

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -162,7 +162,7 @@ const Header = () => {
         stickyMenu ? "shadow-nav" : "shadow-md"
       }`}
     >
-      <div className={`max-w-[1170px] mx-auto px-4 sm:px-7.5 xl:px-0 ${stickyMenu ? "py-3 lg:py-3.5" : "py-4 lg:py-5"}`}> {/* Adjusted padding for sticky */}
+      <div className={`max-w-[1170px] mx-auto px-4 sm:px-7.5 lg:px-0 ${stickyMenu ? "py-3 lg:py-3.5" : "py-4 lg:py-5"}`}> {/* Adjusted padding for sticky */}
         <div className="flex items-center justify-between gap-4">
           <div className="flex flex-col leading-none">
             <Link
@@ -245,7 +245,7 @@ const Header = () => {
               aria-label="Toggle mobile menu"
               aria-expanded={navigationOpen}
               aria-controls="mobile-menu-panel"
-              className="xl:hidden block focus:outline-none text-gray-700 hover:text-accent"
+              className="lg:hidden block focus:outline-none text-gray-700 hover:text-accent"
               onClick={() => setNavigationOpen(!navigationOpen)}
             >
               {navigationOpen ? <X size={24} /> : <MenuIcon size={24} />}
@@ -255,10 +255,10 @@ const Header = () => {
       </div>
 
       <div className="border-t border-gray-200">
-        <div className="max-w-[1170px] mx-auto px-4 sm:px-7.5 xl:px-0">
+        <div className="max-w-[1170px] mx-auto px-4 sm:px-7.5 lg:px-0">
           <div className="flex items-center justify-between">
-            <nav className="hidden xl:flex overflow-x-auto scrollbar-none">
-              <ul className="flex items-center gap-x-6 xl:gap-x-8">
+            <nav className="hidden lg:flex overflow-x-auto scrollbar-none">
+              <ul className="flex items-center gap-x-6 lg:gap-x-8">
                 {headerMenuData.map((menuItem, i) => (
                   menuItem.submenu ? (
                     <Dropdown key={i} item={menuItem} stickyMenu={stickyMenu} openSubMenu={openSubMenu} handleSubMenuToggle={handleSubMenuToggle} />
@@ -274,7 +274,7 @@ const Header = () => {
               </ul>
             </nav>
 
-            <div className="hidden xl:flex items-center gap-x-6">
+            <div className="hidden lg:flex items-center gap-x-6">
               <Link href="/shop-with-sidebar?ordering=-view_count" className="flex items-center gap-1.5 text-sm font-medium text-gray-700 hover:text-accent transition-colors">
                 <svg className="fill-current" width="16" height="16" viewBox="0 0 16 16"><path d="M2.45313 7.55556H1.70313V7.55556L2.45313 7.55556ZM2.45313 8.66667L1.92488 9.19908C2.21729 9.4892 2.68896 9.4892 2.98137 9.19908L2.45313 8.66667ZM4.10124 8.08797C4.39528 7.79623 4.39715 7.32135 4.10541 7.02731C3.81367 6.73327 3.3388 6.73141 3.04476 7.02315L4.10124 8.08797ZM1.86149 7.02315C1.56745 6.73141 1.09258 6.73327 0.800843 7.02731C0.509102 7.32135 0.510968 7.79623 0.805009 8.08797L1.86149 7.02315ZM12.1973 5.05946C12.4143 5.41232 12.8762 5.52252 13.229 5.30558C13.5819 5.08865 13.6921 4.62674 13.4752 4.27388L12.1973 5.05946ZM8.0525 1.25C4.5514 1.25 1.70313 4.06755 1.70313 7.55556H3.20313C3.20313 4.90706 5.3687 2.75 8.0525 2.75V1.25ZM1.70313 7.55556L1.70313 8.66667L3.20313 8.66667L3.20313 7.55556L1.70313 7.55556ZM2.98137 9.19908L4.10124 8.08797L3.04476 7.02315L1.92488 8.13426L2.98137 9.19908ZM2.98137 8.13426L1.86149 7.02315L0.805009 8.08797L1.92488 9.19908L2.98137 8.13426ZM13.4752 4.27388C12.3603 2.46049 10.3479 1.25 8.0525 1.25V2.75C9.80904 2.75 11.346 3.67466 12.1973 5.05946L13.4752 4.27388Z" fill="currentColor"/><path d="M13.5427 7.33337L14.0699 6.79996C13.7777 6.51118 13.3076 6.51118 13.0155 6.79996L13.5427 7.33337ZM11.8913 7.91107C11.5967 8.20225 11.5939 8.67711 11.8851 8.97171C12.1763 9.26631 12.6512 9.26908 12.9458 8.9779L11.8913 7.91107ZM14.1396 8.9779C14.4342 9.26908 14.9091 9.26631 15.2003 8.97171C15.4914 8.67711 15.4887 8.20225 15.1941 7.91107L14.1396 8.9779ZM3.75812 10.9395C3.54059 10.587 3.07849 10.4776 2.72599 10.6951C2.3735 10.9127 2.26409 11.3748 2.48163 11.7273L3.75812 10.9395ZM7.9219 14.75C11.4321 14.75 14.2927 11.9352 14.2927 8.44449H12.7927C12.7927 11.0903 10.6202 13.25 7.9219 13.25V14.75ZM14.2927 8.44449V7.33337H12.7927V8.44449H14.2927ZM13.0155 6.79996L11.8913 7.91107L12.9458 8.9779L14.0699 7.86679L13.0155 6.79996ZM13.0155 7.86679L14.1396 8.9779L15.1941 7.91107L14.0699 6.79996L13.0155 7.86679ZM2.48163 11.7273C3.60082 13.5408 5.62007 14.75 7.9219 14.75V13.25C6.15627 13.25 4.61261 12.3241 3.75812 10.9395L2.48163 11.7273Z" fill="currentColor"/></svg>
                 Recently Viewed
@@ -291,7 +291,7 @@ const Header = () => {
       <div
         ref={mobileMenuDropdown}
         id="mobile-menu-panel"
-        className={`xl:hidden fixed inset-x-0 top-0 mt-[70px] sm:mt-[80px] w-full h-[calc(100vh-70px)] sm:h-[calc(100vh-80px)] bg-white shadow-lg border-t border-gray-200 transform transition-transform duration-300 ease-in-out ${
+        className={`lg:hidden fixed inset-x-0 top-0 mt-[70px] sm:mt-[80px] w-full h-[calc(100vh-70px)] sm:h-[calc(100vh-80px)] bg-white shadow-lg border-t border-gray-200 transform transition-transform duration-300 ease-in-out ${
           navigationOpen ? "translate-x-0" : "translate-x-full"
         } p-5 overflow-y-auto`}
       >


### PR DESCRIPTION
## Summary
- adjust navigation bar breakpoints so dropdowns overlay from large screens

## Testing
- `npm run lint` *(fails: next not found)*