### PR TITLE
Enable email password reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Environment variables
+.env
+
+# Node modules
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,22 @@ This project contains a Django backend and a Next.js frontend.
    ```bash
    python backend/manage.py runserver 0.0.0.0:8000
    ```
-   The server will listen on port `8000` on all network interfaces.
+The server will listen on port `8000` on all network interfaces.
+
+Create a `backend/.env` file to store sensitive settings. Example:
+
+```bash
+SECRET_KEY=changeme
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_HOST_USER=your-email@example.com
+EMAIL_HOST_PASSWORD=your-password
+EMAIL_USE_TLS=True
+DEFAULT_FROM_EMAIL=webmaster@example.com
+```
+
+The `.env` file is already listed in `.gitignore` so it won't be committed.
 
 ## Frontend
 1. Install dependencies:

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -59,8 +59,12 @@ class PasswordResetSerializer(serializers.Serializer):
     def save(self, request=None):
         form = PasswordResetForm({"email": self.validated_data["email"]})
         if form.is_valid():
-            form.save(request=request, use_https=request.is_secure() if request else False,
-                      email_template_name="registration/password_reset_email.html")
+            form.save(
+                request=request,
+                use_https=request.is_secure() if request else False,
+                email_template_name="registration/password_reset_email.txt",
+                html_email_template_name="registration/password_reset_email.html",
+            )
         return True
 
 # class UserProfileSerializer(serializers.ModelSerializer):

--- a/backend/accounts/templates/registration/password_reset_email.html
+++ b/backend/accounts/templates/registration/password_reset_email.html
@@ -1,0 +1,27 @@
+{% autoescape off %}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+  body {background-color:#f8f9fa;font-family:Arial,Helvetica,sans-serif;padding:20px;}
+  .container {max-width:600px;margin:0 auto;background:#ffffff;border-radius:8px;padding:20px;}
+  h2 {color:#1e40af;}
+  .btn {display:inline-block;margin-top:20px;padding:10px 20px;background:#1e40af;color:#ffffff;text-decoration:none;border-radius:4px;}
+  p {line-height:1.5;color:#333333;}
+</style>
+</head>
+<body>
+  <div class="container">
+    <h2>Password Reset Requested</h2>
+    <p>Hello {{ user.get_username }},</p>
+    <p>We received a request to reset your password. Click the button below to choose a new one.</p>
+    <p style="text-align:center;">
+      <a class="btn" href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">Reset Password</a>
+    </p>
+    <p>If you did not request a password reset, please ignore this email.</p>
+    <p>Thanks,<br>The MyEstore Team</p>
+  </div>
+</body>
+</html>
+{% endautoescape %}

--- a/backend/accounts/templates/registration/password_reset_email.txt
+++ b/backend/accounts/templates/registration/password_reset_email.txt
@@ -1,0 +1,11 @@
+Hello {{ user.get_username }},
+
+You're receiving this email because you requested a password reset for your user account at {{ site_name }}.
+
+Please go to the following page and choose a new password:
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+If you didn't request this, you can ignore this email.
+
+Thanks,
+The MyEstore Team

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -19,10 +20,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure--q56@mk$%ov5u8so)8-hlpf1jbkrjwj)cxue4!9lm@94$9sm1!'
+SECRET_KEY = config('SECRET_KEY', default='django-insecure--q56@mk$%ov5u8so)8-hlpf1jbkrjwj)cxue4!9lm@94$9sm1!')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', default=True, cast=bool)
 
 ALLOWED_HOSTS = ["*"]
 # Allow all hosts during local development so the server is reachable from other
@@ -160,8 +161,17 @@ MEDIA_ROOT = BASE_DIR / 'media'  # BASE_DIR is usually defined at the top of set
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-# Development email backend
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# Email configuration
+EMAIL_BACKEND = config(
+    'EMAIL_BACKEND',
+    default='django.core.mail.backends.console.EmailBackend'
+)
+EMAIL_HOST = config('EMAIL_HOST', default='localhost')
+EMAIL_PORT = config('EMAIL_PORT', default=25, cast=int)
+EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
+EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=False, cast=bool)
+DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='webmaster@localhost')
 
 # backend/your_project_name/settings.py
 

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('api/wishlists/', include('wishlists.urls')),
     path('api/carts/', include('carts.urls')),
     path('api/testimonials/', include('testimonials.urls')),
+    path('accounts/', include('django.contrib.auth.urls')),
     # You would add other app API urls here, e.g.:
     # path('api/users/', include('users.urls')), # If 'users' app is at the root of backend/
     # path('api/orders/', include('orders.urls')), # If 'orders' app is at the root of backend/


### PR DESCRIPTION
## Summary
- add `.env` handling and email settings
- create password reset email templates
- enable Django auth URLs for password reset confirmation
- support HTML emails in password reset serializer
- document `.env` usage and ignore it

## Testing
- `python backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*