### PR TITLE
Make navigation bar transparent

### DIFF
--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -152,13 +152,13 @@ const Header = () => {
 
   if (authIsLoading && typeof window !== "undefined" && localStorage.getItem("access_token")) {
     // Potentially show a minimal loading state or rely on the main app preloader
-    return <div className="h-[70px] sm:h-[80px] bg-white"></div>; // Placeholder height
+    return <div className="h-[70px] sm:h-[80px] bg-transparent"></div>; // Placeholder height
   }
 
 
   return (
     <header
-      className={`fixed left-0 top-0 w-full z-[9999] bg-white bg-opacity-90 backdrop-blur-sm transition-all ease-in-out duration-300 ${
+      className={`fixed left-0 top-0 w-full z-[9999] bg-transparent transition-all ease-in-out duration-300 ${
         stickyMenu ? "shadow-nav" : "shadow-md"
       }`}
     >


### PR DESCRIPTION
## Summary
- allow page content to show through the header
- keep placeholder height transparent

## Testing
- `npm run lint` *(fails: `next` not found)*