### PR TITLE
Add team page with theme toggle

### DIFF
--- a/frontend/src/app/(site)/(pages)/team/page.tsx
+++ b/frontend/src/app/(site)/(pages)/team/page.tsx
@@ -1,0 +1,17 @@
+import Team from "@/components/Team";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Team | NextCommerce",
+  description: "Meet our awesome team",
+};
+
+const TeamPage = () => {
+  return (
+    <main>
+      <Team />
+    </main>
+  );
+};
+
+export default TeamPage;

--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -36,6 +36,15 @@ export default function RootLayout({
     setTimeout(() => setLoading(false), 1000); // Simulating asset loading
   }, []);
 
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const storedTheme = localStorage.getItem("theme");
+      if (storedTheme === "dark") {
+        document.documentElement.classList.add("dark");
+      }
+    }
+  }, []);
+
   return (
     <html lang="en" suppressHydrationWarning={true}>
       <body>

--- a/frontend/src/components/Common/ThemeToggle.tsx
+++ b/frontend/src/components/Common/ThemeToggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+const ThemeToggle = () => {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("theme");
+      if (stored === "dark") {
+        document.documentElement.classList.add("dark");
+        setTheme("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+        setTheme("light");
+      }
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    if (newTheme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    if (typeof window !== "undefined") {
+      localStorage.setItem("theme", newTheme);
+    }
+  };
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+      className="text-gray-700 hover:text-accent dark:text-gray-200"
+    >
+      {theme === "dark" ? <Sun size={20} /> : <Moon size={20} />}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -17,6 +17,7 @@ import { logout, setAuthState, loadUserFromStorage } from "@/redux/features/auth
 import { User, AuthTokens } from "@/types/user"; // Import User and AuthTokens types
 import { toast } from "react-toastify";
 import { LogOut, UserCircle2, ShoppingBag, Search, Menu as MenuIcon, X } from 'lucide-react';
+import ThemeToggle from "../Common/ThemeToggle";
 
 
 const Header = () => {
@@ -153,14 +154,14 @@ const Header = () => {
   if (authIsLoading && typeof window !== "undefined" && localStorage.getItem("access_token")) {
     // Potentially show a minimal loading state or rely on the main app preloader
     return (
-      <div className="h-[70px] sm:h-[80px] bg-gradient-to-r from-accent via-orange-400 to-orange"></div>
+      <div className="h-[70px] sm:h-[80px] bg-gradient-to-r from-accent via-orange-400 to-orange dark:from-gray-900 dark:via-gray-800 dark:to-gray-700"></div>
     ); // Placeholder height
   }
 
 
   return (
     <header
-      className={`fixed left-0 top-0 w-full z-[9999] bg-gradient-to-r from-accent via-orange-400 to-orange transition-all ease-in-out duration-300 ${
+      className={`fixed left-0 top-0 w-full z-[9999] bg-gradient-to-r from-accent via-orange-400 to-orange dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 text-gray-700 dark:text-gray-200 transition-all ease-in-out duration-300 ${
         stickyMenu ? "shadow-nav" : "shadow-md"
       }`}
     >
@@ -208,7 +209,7 @@ const Header = () => {
           <div className="flex items-center gap-3 sm:gap-5">
             {isAuthenticated && user ? (
               <div className="hidden sm:flex items-center gap-3">
-                <Link href="/my-account" className="flex items-center gap-2 text-sm text-gray-700 hover:text-accent transition-colors">
+                <Link href="/my-account" className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200 hover:text-accent transition-colors">
                   <UserCircle2 size={22} />
                   <div className="text-left">
                     <span className="block text-xs text-gray-500 uppercase">Welcome</span>
@@ -220,7 +221,7 @@ const Header = () => {
                 </button>
               </div>
             ) : (
-              <Link href="/signin" className="hidden sm:flex items-center gap-2 text-sm text-gray-700 hover:text-accent transition-colors">
+              <Link href="/signin" className="hidden sm:flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200 hover:text-accent transition-colors">
                 <UserCircle2 size={22} />
                 <div className="text-left">
                   <span className="block text-xs text-gray-500 uppercase">Account</span>
@@ -229,7 +230,7 @@ const Header = () => {
               </Link>
             )}
 
-            <button onClick={openCartModal} className="flex items-center gap-2 text-sm text-gray-700 hover:text-accent transition-colors relative" aria-label="Open cart">
+            <button onClick={openCartModal} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200 hover:text-accent transition-colors relative" aria-label="Open cart">
               <span className="relative">
                 <ShoppingBag size={22} />
                 <span className={`flex items-center justify-center text-xs absolute -right-2.5 -top-2.5 bg-accent w-5 h-5 rounded-full text-white shadow-sm ${cartItems.length === 0 ? 'hidden' : ''}`}>
@@ -242,12 +243,14 @@ const Header = () => {
               </div>
             </button>
 
+            <ThemeToggle />
+
             <button
               ref={mobileMenuTrigger}
               aria-label="Toggle mobile menu"
               aria-expanded={navigationOpen}
               aria-controls="mobile-menu-panel"
-              className="lg:hidden block focus:outline-none text-gray-700 hover:text-accent"
+              className="lg:hidden block focus:outline-none text-gray-700 dark:text-gray-200 hover:text-accent"
               onClick={() => setNavigationOpen(!navigationOpen)}
             >
               {navigationOpen ? <X size={24} /> : <MenuIcon size={24} />}
@@ -266,7 +269,7 @@ const Header = () => {
                     <Dropdown key={i} item={menuItem} stickyMenu={stickyMenu} openSubMenu={openSubMenu} handleSubMenuToggle={handleSubMenuToggle} />
                   ) : (
                     <li key={i} className="group relative">
-                      <Link href={menuItem.path || "#"} className={`text-sm font-medium text-gray-700 hover:text-accent transition-colors duration-200 flex items-center ${stickyMenu ? "py-3.5" : "py-5"}`}> {/* Adjusted padding */}
+                      <Link href={menuItem.path || "#"} className={`text-sm font-medium text-gray-700 dark:text-gray-200 hover:text-accent transition-colors duration-200 flex items-center ${stickyMenu ? "py-3.5" : "py-5"}`}> {/* Adjusted padding */}
                         {menuItem.title}
                       </Link>
                       <span className="absolute bottom-0 left-0 w-full h-0.5 bg-accent scale-x-0 group-hover:scale-x-100 transition-transform duration-300 ease-out"></span>
@@ -277,11 +280,11 @@ const Header = () => {
             </nav>
 
             <div className="hidden lg:flex items-center gap-x-6">
-              <Link href="/shop-with-sidebar?ordering=-view_count" className="flex items-center gap-1.5 text-sm font-medium text-gray-700 hover:text-accent transition-colors">
+              <Link href="/shop-with-sidebar?ordering=-view_count" className="flex items-center gap-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:text-accent transition-colors">
                 <svg className="fill-current" width="16" height="16" viewBox="0 0 16 16"><path d="M2.45313 7.55556H1.70313V7.55556L2.45313 7.55556ZM2.45313 8.66667L1.92488 9.19908C2.21729 9.4892 2.68896 9.4892 2.98137 9.19908L2.45313 8.66667ZM4.10124 8.08797C4.39528 7.79623 4.39715 7.32135 4.10541 7.02731C3.81367 6.73327 3.3388 6.73141 3.04476 7.02315L4.10124 8.08797ZM1.86149 7.02315C1.56745 6.73141 1.09258 6.73327 0.800843 7.02731C0.509102 7.32135 0.510968 7.79623 0.805009 8.08797L1.86149 7.02315ZM12.1973 5.05946C12.4143 5.41232 12.8762 5.52252 13.229 5.30558C13.5819 5.08865 13.6921 4.62674 13.4752 4.27388L12.1973 5.05946ZM8.0525 1.25C4.5514 1.25 1.70313 4.06755 1.70313 7.55556H3.20313C3.20313 4.90706 5.3687 2.75 8.0525 2.75V1.25ZM1.70313 7.55556L1.70313 8.66667L3.20313 8.66667L3.20313 7.55556L1.70313 7.55556ZM2.98137 9.19908L4.10124 8.08797L3.04476 7.02315L1.92488 8.13426L2.98137 9.19908ZM2.98137 8.13426L1.86149 7.02315L0.805009 8.08797L1.92488 9.19908L2.98137 8.13426ZM13.4752 4.27388C12.3603 2.46049 10.3479 1.25 8.0525 1.25V2.75C9.80904 2.75 11.346 3.67466 12.1973 5.05946L13.4752 4.27388Z" fill="currentColor"/><path d="M13.5427 7.33337L14.0699 6.79996C13.7777 6.51118 13.3076 6.51118 13.0155 6.79996L13.5427 7.33337ZM11.8913 7.91107C11.5967 8.20225 11.5939 8.67711 11.8851 8.97171C12.1763 9.26631 12.6512 9.26908 12.9458 8.9779L11.8913 7.91107ZM14.1396 8.9779C14.4342 9.26908 14.9091 9.26631 15.2003 8.97171C15.4914 8.67711 15.4887 8.20225 15.1941 7.91107L14.1396 8.9779ZM3.75812 10.9395C3.54059 10.587 3.07849 10.4776 2.72599 10.6951C2.3735 10.9127 2.26409 11.3748 2.48163 11.7273L3.75812 10.9395ZM7.9219 14.75C11.4321 14.75 14.2927 11.9352 14.2927 8.44449H12.7927C12.7927 11.0903 10.6202 13.25 7.9219 13.25V14.75ZM14.2927 8.44449V7.33337H12.7927V8.44449H14.2927ZM13.0155 6.79996L11.8913 7.91107L12.9458 8.9779L14.0699 7.86679L13.0155 6.79996ZM13.0155 7.86679L14.1396 8.9779L15.1941 7.91107L14.0699 6.79996L13.0155 7.86679ZM2.48163 11.7273C3.60082 13.5408 5.62007 14.75 7.9219 14.75V13.25C6.15627 13.25 4.61261 12.3241 3.75812 10.9395L2.48163 11.7273Z" fill="currentColor"/></svg>
                 Recently Viewed
               </Link>
-              <Link href="/wishlist" className="flex items-center gap-1.5 text-sm font-medium text-gray-700 hover:text-accent transition-colors">
+              <Link href="/wishlist" className="flex items-center gap-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:text-accent transition-colors">
                 <svg className="fill-current" width="16" height="16" viewBox="0 0 16 16"><path d="M5.97441 12.6073L6.43872 12.0183L5.97441 12.6073ZM7.99992 3.66709L7.45955 4.18719C7.60094 4.33408 7.79604 4.41709 7.99992 4.41709C8.2038 4.41709 8.3989 4.33408 8.54028 4.18719L7.99992 3.66709ZM10.0254 12.6073L10.4897 13.1962L10.0254 12.6073ZM6.43872 12.0183C5.41345 11.21 4.33627 10.4524 3.47904 9.48717C2.64752 8.55085 2.08325 7.47831 2.08325 6.0914H0.583252C0.583252 7.94644 1.3588 9.35867 2.35747 10.4832C3.33043 11.5788 4.57383 12.4582 5.51009 13.1962L6.43872 12.0183ZM2.08325 6.0914C2.08325 4.75102 2.84027 3.63995 3.85342 3.17683C4.81929 2.73533 6.15155 2.82823 7.45955 4.18719L8.54028 3.14699C6.84839 1.38917 4.84732 1.07324 3.22983 1.8126C1.65962 2.53035 0.583252 4.18982 0.583252 6.0914H2.08325ZM5.51009 13.1962C5.84928 13.4636 6.22932 13.7618 6.61834 13.9891C7.00711 14.2163 7.47619 14.4167 7.99992 14.4167V12.9167C7.85698 12.9167 7.65939 12.8601 7.37512 12.694C7.0911 12.5281 6.79171 12.2965 6.43872 12.0183L5.51009 13.1962ZM10.4897 13.1962C11.426 12.4582 12.6694 11.5788 13.6424 10.4832C14.641 9.35867 15.4166 7.94644 15.4166 6.0914H13.9166C13.9166 7.47831 13.3523 8.55085 12.5208 9.48717C11.6636 10.4524 10.5864 11.21 9.56112 12.0183L10.4897 13.1962ZM15.4166 6.0914C15.4166 4.18982 14.3402 2.53035 12.77 1.8126C11.1525 1.07324 9.15145 1.38917 7.45955 3.14699L8.54028 4.18719C9.84828 2.82823 11.1805 2.73533 12.1464 3.17683C13.1596 3.63995 13.9166 4.75102 13.9166 6.0914H15.4166ZM9.56112 12.0183C9.20813 12.2965 8.90874 12.5281 8.62471 12.694C8.34044 12.8601 8.14285 12.9167 7.99992 12.9167V14.4167C8.52365 14.4167 8.99273 14.2163 9.3815 13.9891C9.77052 13.7618 10.1506 13.4636 10.4897 13.1962L9.56112 12.0183Z" fill="currentColor"/></svg>
                 Wishlist
               </Link>
@@ -331,7 +334,7 @@ const Header = () => {
               <div key={menuItem.id} className="py-1 border-b border-gray-100 last:border-b-0">
                 <button
                   onClick={() => handleSubMenuToggle(menuItem.id)}
-                  className="w-full flex justify-between items-center text-gray-700 hover:text-accent py-2.5 transition-colors"
+                  className="w-full flex justify-between items-center text-gray-700 dark:text-gray-200 hover:text-accent py-2.5 transition-colors"
                   aria-expanded={openSubMenu === menuItem.id}
                 >
                   <span className="font-medium">{menuItem.title}</span>
@@ -349,7 +352,7 @@ const Header = () => {
               </div>
             ) : (
               <div key={menuItem.id} className="py-1 border-b border-gray-100 last:border-b-0">
-                <Link href={menuItem.path || "#"} className="block text-gray-700 hover:text-accent py-2.5 font-medium transition-colors" onClick={() => setNavigationOpen(false)}>
+                <Link href={menuItem.path || "#"} className="block text-gray-700 dark:text-gray-200 hover:text-accent py-2.5 font-medium transition-colors" onClick={() => setNavigationOpen(false)}>
                   {menuItem.title}
                 </Link>
               </div>
@@ -358,15 +361,15 @@ const Header = () => {
           {isAuthenticated ? (
             <>
               <div className="py-1 border-b border-gray-100">
-                <Link href="/my-account" className="block text-gray-700 hover:text-accent py-2.5 font-medium transition-colors" onClick={() => setNavigationOpen(false)}>My Account</Link>
+                <Link href="/my-account" className="block text-gray-700 dark:text-gray-200 hover:text-accent py-2.5 font-medium transition-colors" onClick={() => setNavigationOpen(false)}>My Account</Link>
               </div>
               <div className="py-1">
-                <button onClick={handleLogout} className="block w-full text-left text-gray-700 hover:text-red-500 py-2.5 font-medium transition-colors">Logout</button>
+                <button onClick={handleLogout} className="block w-full text-left text-gray-700 dark:text-gray-200 hover:text-red-500 py-2.5 font-medium transition-colors">Logout</button>
               </div>
             </>
           ) : (
             <div className="py-1 border-b border-gray-100">
-              <Link href="/signin" className="block text-gray-700 hover:text-accent py-2.5 font-medium transition-colors" onClick={() => setNavigationOpen(false)}>Sign In</Link>
+              <Link href="/signin" className="block text-gray-700 dark:text-gray-200 hover:text-accent py-2.5 font-medium transition-colors" onClick={() => setNavigationOpen(false)}>Sign In</Link>
             </div>
           )}
         </nav>

--- a/frontend/src/components/Team/index.tsx
+++ b/frontend/src/components/Team/index.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import Breadcrumb from "../Common/Breadcrumb";
+
+const members = [
+  { name: "Alice Johnson", role: "CEO", image: "/images/blog/blog-01.jpg" },
+  { name: "Bob Smith", role: "CTO", image: "/images/blog/blog-02.jpg" },
+  { name: "Carol Lee", role: "Design Lead", image: "/images/blog/blog-03.jpg" },
+  { name: "David Kim", role: "Marketing", image: "/images/blog/blog-04.jpg" },
+];
+
+const Team = () => (
+  <>
+    <Breadcrumb title="Our Team" pages={["team"]} />
+    <section className="py-20 bg-white dark:bg-gray-900">
+      <div className="max-w-[1170px] mx-auto px-4 sm:px-8 xl:px-0">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+          {members.map((m) => (
+            <div
+              key={m.name}
+              className="p-5 text-center rounded-lg shadow-lg bg-gradient-to-br from-teal-100 to-teal-50 dark:from-gray-800 dark:to-gray-700"
+            >
+              <Image
+                src={m.image}
+                alt={m.name}
+                width={200}
+                height={200}
+                className="mx-auto mb-4 rounded-full"
+              />
+              <h3 className="text-lg font-semibold text-dark dark:text-white">
+                {m.name}
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-300">{m.role}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  </>
+);
+
+export default Team;


### PR DESCRIPTION
## Summary
- implement ThemeToggle component for switching dark/light mode
- support persisting theme in RootLayout
- add ThemeToggle to the navigation bar and style header for dark mode
- create colorful Team component and page

## Testing
- `npm run lint` *(fails: next not found)*
- `python -m pytest -q`
