### PR TITLE
Implement dynamic home slideshows and banners

### DIFF
--- a/backend/shop/admin.py
+++ b/backend/shop/admin.py
@@ -1,5 +1,13 @@
 from django.contrib import admin
-from .models import Brand, PhoneModel, Category, Product, ProductMedia  # Changed ProductImage to ProductMedia
+from .models import (
+    Brand,
+    PhoneModel,
+    Category,
+    Product,
+    ProductMedia,
+    SlideshowItem,
+    PromoBanner,
+)
 
 
 class ProductMediaInline(admin.TabularInline):
@@ -145,3 +153,17 @@ class ProductMediaAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         # Optimize queries by prefetching related product data
         return super().get_queryset(request).select_related('product')
+
+
+@admin.register(SlideshowItem)
+class SlideshowItemAdmin(admin.ModelAdmin):
+    list_display = ('product', 'order', 'is_active', 'created_at')
+    list_editable = ('order', 'is_active')
+    list_select_related = ('product',)
+
+
+@admin.register(PromoBanner)
+class PromoBannerAdmin(admin.ModelAdmin):
+    list_display = ('product', 'size', 'order', 'is_active', 'created_at')
+    list_editable = ('size', 'order', 'is_active')
+    list_select_related = ('product',)

--- a/backend/shop/migrations/0002_promotions.py
+++ b/backend/shop/migrations/0002_promotions.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shop', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SlideshowItem',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('order', models.PositiveIntegerField(default=0)),
+                ('is_active', models.BooleanField(default=True)),
+                ('product', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='slideshow_items', to='shop.product')),
+            ],
+            options={
+                'ordering': ['order', 'created_at'],
+            },
+        ),
+        migrations.CreateModel(
+            name='PromoBanner',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('size', models.CharField(choices=[('large', 'Large'), ('small', 'Small')], default='small', max_length=10)),
+                ('order', models.PositiveIntegerField(default=0)),
+                ('is_active', models.BooleanField(default=True)),
+                ('product', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='promo_banners', to='shop.product')),
+            ],
+            options={
+                'ordering': ['order', 'created_at'],
+            },
+        ),
+    ]

--- a/backend/shop/models.py
+++ b/backend/shop/models.py
@@ -215,3 +215,37 @@ class ProductMedia(TimeStampedModel):  # <<<--- THIS IS THE CLASS DEFINITION
                 raise ValidationError(
                     f"Unsupported image file extension: {ext}. Allowed: {', '.join(valid_image_extensions)}")
             self.video_thumbnail = None
+
+
+class SlideshowItem(TimeStampedModel):
+    """Model to control which products appear in the hero carousel."""
+
+    product = models.ForeignKey(Product, related_name='slideshow_items', on_delete=models.CASCADE)
+    order = models.PositiveIntegerField(default=0)
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        ordering = ['order', 'created_at']
+
+    def __str__(self):
+        return f"Slide: {self.product.name}"
+
+
+class PromoBanner(TimeStampedModel):
+    """Model for promotional banners displayed on the home page."""
+
+    SIZE_CHOICES = [
+        ('large', 'Large'),
+        ('small', 'Small'),
+    ]
+
+    product = models.ForeignKey(Product, related_name='promo_banners', on_delete=models.CASCADE)
+    size = models.CharField(max_length=10, choices=SIZE_CHOICES, default='small')
+    order = models.PositiveIntegerField(default=0)
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        ordering = ['order', 'created_at']
+
+    def __str__(self):
+        return f"Banner: {self.product.name} ({self.size})"

--- a/backend/shop/urls.py
+++ b/backend/shop/urls.py
@@ -2,13 +2,20 @@
 
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import CategoryViewSet, ProductViewSet
+from .views import (
+    CategoryViewSet,
+    ProductViewSet,
+    SlideshowItemViewSet,
+    PromoBannerViewSet,
+)
 from reviews.views import ProductReviewViewSet
 
 # Create a router and register our viewsets with it.
 router = DefaultRouter()
 router.register(r'categories', CategoryViewSet, basename='category')
 router.register(r'products', ProductViewSet, basename='product')
+router.register(r'slides', SlideshowItemViewSet, basename='slideshowitem')
+router.register(r'banners', PromoBannerViewSet, basename='promobanner')
 
 # Manual nested routes for product reviews without requiring drf-nested-routers
 review_list = ProductReviewViewSet.as_view({

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -2,8 +2,13 @@
 
 from rest_framework import viewsets, permissions, filters
 from django_filters.rest_framework import DjangoFilterBackend # For advanced filtering
-from .models import Category, Product
-from .serializers import CategorySerializer, ProductSerializer
+from .models import Category, Product, SlideshowItem, PromoBanner
+from .serializers import (
+    CategorySerializer,
+    ProductSerializer,
+    SlideshowItemSerializer,
+    PromoBannerSerializer,
+)
 from django.db.models import Count
 
 # Optional: Custom permissions (e.g., IsAdminOrReadOnly)
@@ -63,3 +68,21 @@ class ProductViewSet(viewsets.ModelViewSet):
         context = super().get_serializer_context()
         context.update({"request": self.request})
         return context
+
+
+class SlideshowItemViewSet(viewsets.ModelViewSet):
+    """API endpoint for hero carousel items."""
+
+    queryset = SlideshowItem.objects.filter(is_active=True).select_related('product')
+    serializer_class = SlideshowItemSerializer
+    permission_classes = [permissions.AllowAny]
+    ordering = ['order', 'created_at']
+
+
+class PromoBannerViewSet(viewsets.ModelViewSet):
+    """API endpoint for promotional banners."""
+
+    queryset = PromoBanner.objects.filter(is_active=True).select_related('product')
+    serializer_class = PromoBannerSerializer
+    permission_classes = [permissions.AllowAny]
+    ordering = ['order', 'created_at']

--- a/frontend/src/components/Home/Hero/HeroCarousel.tsx
+++ b/frontend/src/components/Home/Hero/HeroCarousel.tsx
@@ -9,17 +9,9 @@ import "swiper/css/pagination";
 import Image from "next/image";
 import Link from "next/link";
 import DiscountBadge from "@/components/Common/DiscountBadge";
-import shopData from "@/components/Shop/shopData";
-
-// Select top discounted products from the demo data
-const heroProducts = shopData
-  .map((p) => ({
-    title: p.title,
-    image: p.imgs?.previews?.[0] || p.imgs?.thumbnails?.[0] || "/images/hero/hero-01.png",
-    discount: Math.round(((p.price - p.discountedPrice) / p.price) * 100),
-  }))
-  .sort((a, b) => b.discount - a.discount)
-  .slice(0, 3);
+import { useEffect, useState } from "react";
+import { getSlideshowItems } from "@/lib/apiService";
+import { SlideshowItem } from "@/types/slideshow";
 
 const gradientClasses = [
   "from-pink-200 via-purple-200 to-indigo-200",
@@ -28,6 +20,22 @@ const gradientClasses = [
 ];
 
 const HeroCarousal = () => {
+  const [slides, setSlides] = useState<SlideshowItem[]>([]);
+
+  useEffect(() => {
+    getSlideshowItems()
+      .then((data) => setSlides(data))
+      .catch((err) => console.error("Failed to load slides", err));
+  }, []);
+  const heroProducts = slides.map((s) => ({
+    title: s.product_details?.name || "",
+    image:
+      s.product_details?.imgs?.previews?.[0] ||
+      s.product_details?.imgs?.thumbnails?.[0] ||
+      "/images/hero/hero-01.png",
+    discount: s.product_details?.get_discount_percentage || 0,
+  }));
+
   return (
     <Swiper
       spaceBetween={30}

--- a/frontend/src/components/Home/PromoBanner/index.tsx
+++ b/frontend/src/components/Home/PromoBanner/index.tsx
@@ -1,108 +1,90 @@
-import React from "react";
+"use client";
+import React, { useEffect, useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
+import { getPromoBanners } from "@/lib/apiService";
+import { PromoBanner as PromoBannerType } from "@/types/promoBanner";
 
 const PromoBanner = () => {
+  const [banners, setBanners] = useState<PromoBannerType[]>([]);
+
+  useEffect(() => {
+    getPromoBanners()
+      .then((data) => setBanners(data))
+      .catch((err) => console.error("Failed to load banners", err));
+  }, []);
+
+  const big = banners.find((b) => b.size === "large");
+  const smalls = banners.filter((b) => b.size === "small").slice(0, 2);
+
   return (
     <section className="overflow-hidden py-20">
       <div className="max-w-[1170px] w-full mx-auto px-4 sm:px-8 xl:px-0">
-        {/* <!-- promo banner big --> */}
-        <div className="relative z-1 overflow-hidden rounded-lg bg-[#F5F5F7] py-12.5 lg:py-17.5 xl:py-22.5 px-4 sm:px-7.5 lg:px-14 xl:px-19 mb-7.5">
-          <div className="max-w-[550px] w-full">
-            <span className="block font-medium text-xl text-dark mb-3">
-              Apple iPhone 14 Plus
-            </span>
-
-            <h2 className="font-bold text-xl lg:text-heading-4 xl:text-heading-3 text-dark mb-5">
-              UP TO 30% OFF
-            </h2>
-
-            <p>
-              iPhone 14 has the same superspeedy chip that’s in iPhone 13 Pro,
-              A15 Bionic, with a 5‑core GPU, powers all the latest features.
-            </p>
-
-            <a
-              href="#"
-              className="inline-flex font-medium text-custom-sm text-white bg-blue py-[11px] px-9.5 rounded-md ease-out duration-200 hover:bg-blue-dark mt-7.5"
-            >
-              Buy Now
-            </a>
-          </div>
-
-          <Image
-            src="/images/promo/promo-01.png"
-            alt="promo img"
-            className="absolute bottom-0 right-4 lg:right-26 -z-1"
-            width={274}
-            height={350}
-          />
-        </div>
-
-        <div className="grid gap-7.5 grid-cols-1 lg:grid-cols-2">
-          {/* <!-- promo banner small --> */}
-          <div className="relative z-1 overflow-hidden rounded-lg bg-[#DBF4F3] py-10 xl:py-16 px-4 sm:px-7.5 xl:px-10">
-            <Image
-              src="/images/promo/promo-02.png"
-              alt="promo img"
-              className="absolute top-1/2 -translate-y-1/2 left-3 sm:left-10 -z-1"
-              width={241}
-              height={241}
-            />
-
-            <div className="text-right">
-              <span className="block text-lg text-dark mb-1.5">
-                Foldable Motorised Treadmill
+        {big && (
+          <div className="relative z-1 overflow-hidden rounded-lg bg-[#F5F5F7] py-12.5 lg:py-17.5 xl:py-22.5 px-4 sm:px-7.5 lg:px-14 xl:px-19 mb-7.5">
+            <div className="max-w-[550px] w-full">
+              <span className="block font-medium text-xl text-dark mb-3">
+                {big.product_details?.name}
               </span>
 
-              <h2 className="font-bold text-xl lg:text-heading-4 text-dark mb-2.5">
-                Workout At Home
+              <h2 className="font-bold text-xl lg:text-heading-4 xl:text-heading-3 text-dark mb-5">
+                UP TO {big.product_details?.get_discount_percentage}% OFF
               </h2>
 
-              <p className="font-semibold text-custom-1 text-teal">
-                Flat 20% off
-              </p>
-
-              <a
-                href="#"
-                className="inline-flex font-medium text-custom-sm text-white bg-teal py-2.5 px-8.5 rounded-md ease-out duration-200 hover:bg-teal-dark mt-9"
-              >
-                Grab Now
-              </a>
-            </div>
-          </div>
-
-          {/* <!-- promo banner small --> */}
-          <div className="relative z-1 overflow-hidden rounded-lg bg-[#FFECE1] py-10 xl:py-16 px-4 sm:px-7.5 xl:px-10">
-            <Image
-              src="/images/promo/promo-03.png"
-              alt="promo img"
-              className="absolute top-1/2 -translate-y-1/2 right-3 sm:right-8.5 -z-1"
-              width={200}
-              height={200}
-            />
-
-            <div>
-              <span className="block text-lg text-dark mb-1.5">
-                Apple Watch Ultra
-              </span>
-
-              <h2 className="font-bold text-xl lg:text-heading-4 text-dark mb-2.5">
-                Up to <span className="text-orange">40%</span> off
-              </h2>
-
-              <p className="max-w-[285px] text-custom-sm">
-                The aerospace-grade titanium case strikes the perfect balance of
-                everything.
-              </p>
-
-              <a
-                href="#"
-                className="inline-flex font-medium text-custom-sm text-white bg-orange py-2.5 px-8.5 rounded-md ease-out duration-200 hover:bg-orange-dark mt-7.5"
+              <Link
+                href={`/product/${big.product_details?.slug}`}
+                className="inline-flex font-medium text-custom-sm text-white bg-blue py-[11px] px-9.5 rounded-md ease-out duration-200 hover:bg-blue-dark mt-7.5"
               >
                 Buy Now
-              </a>
+              </Link>
             </div>
+
+            {big.product_details?.imgs?.previews?.[0] && (
+              <Image
+                src={big.product_details.imgs.previews[0]}
+                alt={big.product_details.name}
+                className="absolute bottom-0 right-4 lg:right-26 -z-1"
+                width={274}
+                height={350}
+              />
+            )}
           </div>
+        )}
+
+        <div className="grid gap-7.5 grid-cols-1 lg:grid-cols-2">
+          {smalls.map((banner, idx) => (
+            <div
+              key={banner.id}
+              className="relative z-1 overflow-hidden rounded-lg bg-[#DBF4F3] py-10 xl:py-16 px-4 sm:px-7.5 xl:px-10"
+            >
+              {banner.product_details?.imgs?.previews?.[0] && (
+                <Image
+                  src={banner.product_details.imgs.previews[0]}
+                  alt={banner.product_details.name}
+                  className={`absolute top-1/2 -translate-y-1/2 ${idx === 0 ? 'left-3 sm:left-10' : 'right-3 sm:right-8.5'} -z-1`}
+                  width={idx === 0 ? 241 : 200}
+                  height={idx === 0 ? 241 : 200}
+                />
+              )}
+
+              <div className={idx === 0 ? 'text-right' : ''}>
+                <span className="block text-lg text-dark mb-1.5">
+                  {banner.product_details?.name}
+                </span>
+
+                <h2 className="font-bold text-xl lg:text-heading-4 text-dark mb-2.5">
+                  Up to {banner.product_details?.get_discount_percentage}% off
+                </h2>
+
+                <Link
+                  href={`/product/${banner.product_details?.slug}`}
+                  className={`inline-flex font-medium text-custom-sm text-white ${idx === 0 ? 'bg-teal hover:bg-teal-dark' : 'bg-orange hover:bg-orange-dark'} py-2.5 px-8.5 rounded-md ease-out duration-200 mt-7.5`}
+                >
+                  Shop Now
+                </Link>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -3,6 +3,8 @@ import { Product, PaginatedProducts, Review, Tag, Order, CreateOrderPayload, Wis
 import { Testimonial } from "@/types/testimonial";
 import { Category } from "@/types/category"; // Corrected: Removed 's'
 import { User, AuthTokens, LoginCredentials, RegisterData, Address, ChangePasswordData } from "@/types/user";
+import { SlideshowItem } from "@/types/slideshow";
+import { PromoBanner } from "@/types/promoBanner";
 
 const API_ROOT = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000/api";
 
@@ -379,4 +381,18 @@ export const createTestimonial = (testimonialData: Omit<Testimonial, 'id' | 'cre
         method: 'POST',
         body: JSON.stringify(testimonialData),
     });
+};
+
+// Slideshow and Promo Banners
+const SLIDES_BASE_URL = `${SHOP_BASE_URL}/slides`;
+const BANNERS_BASE_URL = `${SHOP_BASE_URL}/banners`;
+
+export const getSlideshowItems = (): Promise<SlideshowItem[]> => {
+    return fetchWrapper<PaginatedResponse<SlideshowItem>>(`${SLIDES_BASE_URL}/`)
+        .then(data => (data as any).results || (data as any as SlideshowItem[]));
+};
+
+export const getPromoBanners = (): Promise<PromoBanner[]> => {
+    return fetchWrapper<PaginatedResponse<PromoBanner>>(`${BANNERS_BASE_URL}/`)
+        .then(data => (data as any).results || (data as any as PromoBanner[]));
 };

--- a/frontend/src/types/promoBanner.ts
+++ b/frontend/src/types/promoBanner.ts
@@ -1,0 +1,12 @@
+import { Product } from './product';
+
+export type PromoBanner = {
+  id: number;
+  product: number;
+  product_details?: Product;
+  size: 'large' | 'small';
+  order: number;
+  is_active: boolean;
+  created_at?: string;
+  updated_at?: string;
+};

--- a/frontend/src/types/slideshow.ts
+++ b/frontend/src/types/slideshow.ts
@@ -1,0 +1,11 @@
+import { Product } from './product';
+
+export type SlideshowItem = {
+  id: number;
+  product: number;
+  product_details?: Product;
+  order: number;
+  is_active: boolean;
+  created_at?: string;
+  updated_at?: string;
+};


### PR DESCRIPTION
## Summary
- add `SlideshowItem` and `PromoBanner` models with migrations and admin
- expose new endpoints and serializers
- fetch slides and banners from API in the frontend
- add TypeScript types and API helpers
- gracefully handle missing media files in serializers

## Testing
- `npm run lint` *(fails: next not found)*
- `python manage.py check` *(fails: Django not installed)*