### PR TITLE
Fix image loading errors

### DIFF
--- a/frontend/src/components/Common/PreviewSlider.tsx
+++ b/frontend/src/components/Common/PreviewSlider.tsx
@@ -110,6 +110,7 @@ const PreviewSliderModal = () => {
                   alt={`${productData.name} - Image ${index + 1}`}
                   width={770} // Max width for the image
                   height={500} // Corresponding height (adjust aspect ratio as needed)
+                  unoptimized
                   className="object-contain max-h-[70vh] w-auto" // Ensure it fits
                   onError={(e) => { (e.target as HTMLImageElement).src = PLACEHOLDER_IMAGE_URL;}}
                 />
@@ -154,6 +155,7 @@ const PreviewSliderModal = () => {
                         alt={`Thumbnail ${index + 1}`}
                         width={80}
                         height={80}
+                        unoptimized
                         className="object-cover w-full h-full"
                         onError={(e) => { (e.target as HTMLImageElement).src = PLACEHOLDER_IMAGE_URL;}}
                     />

--- a/frontend/src/components/Common/ProductItem.tsx
+++ b/frontend/src/components/Common/ProductItem.tsx
@@ -146,6 +146,7 @@ const ProductItem = ({ item }: { item: Product }) => {
             alt={item.name || "Product image"}
             width={250}
             height={250}
+            unoptimized
             className="object-contain w-full h-full group-hover:scale-105 transition-transform duration-300 ease-in-out"
             onError={(e) => {
               (e.target as HTMLImageElement).onerror = null;

--- a/frontend/src/components/Common/QuickViewModal.tsx
+++ b/frontend/src/components/Common/QuickViewModal.tsx
@@ -230,6 +230,7 @@ const QuickViewModal = () => {
                     alt={product.name || "Product image"}
                     width={600}
                     height={400}
+                    unoptimized
                     className="h-auto w-full rounded-lg object-cover"
                     onError={(e) => {
                         // Fallback to placeholder if the single product image fails to load
@@ -244,6 +245,7 @@ const QuickViewModal = () => {
                     alt={product.name || "Product image placeholder"}
                     width={600}
                     height={400}
+                    unoptimized
                     className="h-auto w-full rounded-lg object-cover"
                     // No onError needed here as it's already the placeholder
                  />

--- a/frontend/src/components/Home/BestSeller/SingleItem.tsx
+++ b/frontend/src/components/Home/BestSeller/SingleItem.tsx
@@ -138,6 +138,7 @@ const SingleItem = ({ item }: { item: Product }) => {
             alt={item.name || "Best seller product image"}
             width={280}
             height={280}
+            unoptimized
             className="object-contain w-full h-full group-hover:scale-105 transition-transform duration-300 ease-in-out"
             onError={(e) => {
               (e.target as HTMLImageElement).onerror = null;

--- a/frontend/src/components/Home/Categories/SingleItem.tsx
+++ b/frontend/src/components/Home/Categories/SingleItem.tsx
@@ -18,6 +18,7 @@ const SingleItem = ({ item }: { item: CategoryType }) => {
           alt={item.name || "Category"}
           width={82}
           height={62}
+          unoptimized
           className="object-contain"
           onError={(e) => {
             (e.target as HTMLImageElement).onerror = null;

--- a/frontend/src/components/Orders/OrderDetails.tsx
+++ b/frontend/src/components/Orders/OrderDetails.tsx
@@ -70,6 +70,7 @@ const OrderDetails = ({ orderItem: order }: OrderDetailsProps) => {
                   alt={item.product_details?.name || "Product Image"}
                   width={60}
                   height={60}
+                  unoptimized
                   className="object-contain"
                   onError={(e) => { (e.target as HTMLImageElement).src = PLACEHOLDER_IMAGE_URL;}}
                 />

--- a/frontend/src/components/Shop/SingleGridItem.tsx
+++ b/frontend/src/components/Shop/SingleGridItem.tsx
@@ -136,6 +136,7 @@ const SingleGridItem = ({ product: item }: { product: Product }) => {
             alt={item.name || "Product image"}
             width={250}
             height={250}
+            unoptimized
             className="object-contain w-full h-full group-hover:scale-105 transition-transform duration-300 ease-in-out"
             onError={(e) => {
               (e.target as HTMLImageElement).onerror = null;

--- a/frontend/src/components/Shop/SingleListItem.tsx
+++ b/frontend/src/components/Shop/SingleListItem.tsx
@@ -144,6 +144,7 @@ const SingleListItem = ({ item }: { item: Product }) => {
               alt={item.name || "Product image"}
               width={250} // Adjust as needed for list view
               height={250} // Adjust as needed for list view
+              unoptimized
               className="object-contain w-full h-full group-hover:scale-105 transition-transform duration-300 ease-in-out"
               onError={(e) => {
                 (e.target as HTMLImageElement).onerror = null;

--- a/frontend/src/components/ShopDetails/index.tsx
+++ b/frontend/src/components/ShopDetails/index.tsx
@@ -205,13 +205,14 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
                       alt={product.name || "Product image"}
                       width={400}
                       height={400}
+                      unoptimized
                       className="rounded-lg object-contain max-h-[450px] transition-transform duration-300 ease-out group-hover:scale-105"
                       onError={(e) => { (e.target as HTMLImageElement).src = PLACEHOLDER_IMAGE_URL; }}
                       priority={true}
                     />
                   </>
                 ) : (
-                  <Image src={PLACEHOLDER_IMAGE_URL} alt="Product image placeholder" width={400} height={400} className="rounded-lg object-contain max-h-[450px] transition-transform duration-300 ease-out group-hover:scale-105" />
+                  <Image src={PLACEHOLDER_IMAGE_URL} alt="Product image placeholder" width={400} height={400} unoptimized className="rounded-lg object-contain max-h-[450px] transition-transform duration-300 ease-out group-hover:scale-105" />
                 )}
               </div>
 
@@ -232,6 +233,7 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
                         height={70}
                         src={imgSrc || PLACEHOLDER_IMAGE_URL}
                         alt={`Thumbnail ${key + 1}`}
+                        unoptimized
                         className="object-contain w-full h-full"
                         onError={(e) => { (e.target as HTMLImageElement).src = PLACEHOLDER_IMAGE_URL; }}
                       />

--- a/frontend/src/components/Wishlist/SingleItem.tsx
+++ b/frontend/src/components/Wishlist/SingleItem.tsx
@@ -108,6 +108,7 @@ const SingleItem = ({ item, onRemoveSuccess }: { item: Product; onRemoveSuccess:
               alt={item.name}
               width={70}
               height={70}
+              unoptimized
               className="object-contain w-full h-full"
               onError={(e) => { (e.target as HTMLImageElement).src = PLACEHOLDER_IMAGE_URL;}}
             />


### PR DESCRIPTION
## Summary
- ensure `next/image` doesn't try to optimize remote assets
- use `unoptimized` on image components

## Testing
- `npm run lint` *(fails: `next` not found)*