### PR TITLE
Fix Next.js image remote patterns

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -11,7 +11,9 @@ const nextConfig = {
       // This lets the frontend load images when accessed from another device
       // using the server's local network address (e.g. 192.168.x.x:8000).
       {
-
+        protocol: protocol.replace(':', ''),
+        hostname,
+        port,
         pathname: '/media/**',
       },
       // Placeholder images


### PR DESCRIPTION
## Summary
- fix Next.js `images.remotePatterns` configuration

## Testing
- `npm run lint` *(fails: next not found)*