### PR TITLE
Fix promo and slideshow image sources

### DIFF
--- a/frontend/src/components/Home/Hero/HeroCarousel.tsx
+++ b/frontend/src/components/Home/Hero/HeroCarousel.tsx
@@ -12,6 +12,7 @@ import DiscountBadge from "@/components/Common/DiscountBadge";
 import { useEffect, useState } from "react";
 import { getSlideshowItems } from "@/lib/apiService";
 import { SlideshowItem } from "@/types/slideshow";
+import { getProductImage } from "@/utils/productImage";
 
 const gradientClasses = [
   "from-pink-200 via-purple-200 to-indigo-200",
@@ -27,14 +28,18 @@ const HeroCarousal = () => {
       .then((data) => setSlides(data))
       .catch((err) => console.error("Failed to load slides", err));
   }, []);
-  const heroProducts = slides.map((s) => ({
-    title: s.product_details?.name || "",
-    image:
-      s.product_details?.imgs?.previews?.[0] ||
-      s.product_details?.imgs?.thumbnails?.[0] ||
-      "/images/hero/hero-01.png",
-    discount: s.product_details?.get_discount_percentage || 0,
-  }));
+  const heroProducts = slides
+    .map((s) => {
+      const p = s.product_details;
+      const imgSrc = getProductImage(p);
+      if (!imgSrc) return null;
+      return {
+        title: p?.name || "",
+        image: imgSrc,
+        discount: p?.get_discount_percentage || 0,
+      };
+    })
+    .filter(Boolean) as { title: string; image: string; discount: number }[];
 
   return (
     <Swiper

--- a/frontend/src/components/Home/PromoBanner/index.tsx
+++ b/frontend/src/components/Home/PromoBanner/index.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { getPromoBanners } from "@/lib/apiService";
 import { PromoBanner as PromoBannerType } from "@/types/promoBanner";
+import { getProductImage } from "@/utils/productImage";
 
 const PromoBanner = () => {
   const [banners, setBanners] = useState<PromoBannerType[]>([]);
@@ -14,8 +15,12 @@ const PromoBanner = () => {
       .catch((err) => console.error("Failed to load banners", err));
   }, []);
 
-  const big = banners.find((b) => b.size === "large");
-  const smalls = banners.filter((b) => b.size === "small").slice(0, 2);
+  const getImage = (product?: any): string | undefined => getProductImage(product);
+
+  const big = banners.find((b) => b.size === "large" && getImage(b.product_details));
+  const smalls = banners
+    .filter((b) => b.size === "small" && getImage(b.product_details))
+    .slice(0, 2);
 
   return (
     <section className="overflow-hidden py-20">
@@ -39,10 +44,10 @@ const PromoBanner = () => {
               </Link>
             </div>
 
-            {big.product_details?.imgs?.previews?.[0] && (
+            {getImage(big.product_details) && (
               <Image
-                src={big.product_details.imgs.previews[0]}
-                alt={big.product_details.name}
+                src={getImage(big.product_details) as string}
+                alt={big.product_details?.name || "Promo image"}
                 className="absolute bottom-0 right-4 lg:right-26 -z-1"
                 width={274}
                 height={350}
@@ -57,10 +62,10 @@ const PromoBanner = () => {
               key={banner.id}
               className="relative z-1 overflow-hidden rounded-lg bg-[#DBF4F3] py-10 xl:py-16 px-4 sm:px-7.5 xl:px-10"
             >
-              {banner.product_details?.imgs?.previews?.[0] && (
+              {getImage(banner.product_details) && (
                 <Image
-                  src={banner.product_details.imgs.previews[0]}
-                  alt={banner.product_details.name}
+                  src={getImage(banner.product_details) as string}
+                  alt={banner.product_details?.name || "Promo image"}
                   className={`absolute top-1/2 -translate-y-1/2 ${idx === 0 ? 'left-3 sm:left-10' : 'right-3 sm:right-8.5'} -z-1`}
                   width={idx === 0 ? 241 : 200}
                   height={idx === 0 ? 241 : 200}

--- a/frontend/src/utils/productImage.ts
+++ b/frontend/src/utils/productImage.ts
@@ -1,0 +1,20 @@
+import { Product, ProductMediaItem } from "@/types/product";
+
+export const getProductImage = (product?: Product): string | undefined => {
+  if (!product) return undefined;
+  let img: string | undefined;
+  if (product.product_media && product.product_media.length > 0) {
+    const media = product.product_media
+      .filter((m: ProductMediaItem) =>
+        m.media_type === "IMG" && (m.is_preview || m.is_thumbnail) && m.file_url
+      )
+      .sort((a: ProductMediaItem, b: ProductMediaItem) => (a.order || 0) - (b.order || 0))[0];
+    img = media?.file_url;
+  }
+  return (
+    img ||
+    product.cover_image_url ||
+    product.imgs?.previews?.[0] ||
+    product.imgs?.thumbnails?.[0]
+  );
+};


### PR DESCRIPTION
## Summary
- prefer product media when grabbing images
- hide promos and slides that lack images

## Testing
- `npm run lint` *(fails: next not found)*