### PR TITLE
Fix hero carousel and menu key issues

### DIFF
--- a/frontend/src/components/Header/menuData.ts
+++ b/frontend/src/components/Header/menuData.ts
@@ -80,7 +80,7 @@ export const menuData: Menu[] = [
         path: "/contact",
       },
       {
-        id: 62,
+        id: 75,
         title: "Error",
         newTab: false,
         path: "/error",

--- a/frontend/src/components/Home/Hero/HeroCarousel.tsx
+++ b/frontend/src/components/Home/Hero/HeroCarousel.tsx
@@ -12,6 +12,7 @@ import DiscountBadge from "@/components/Common/DiscountBadge";
 import { useEffect, useState } from "react";
 import { getSlideshowItems } from "@/lib/apiService";
 import { SlideshowItem } from "@/types/slideshow";
+import { getProductImage } from "@/utils/productImage";
 
 
 const gradientClasses = [
@@ -28,6 +29,19 @@ const HeroCarousal = () => {
       .then((data) => setSlides(data))
       .catch((err) => console.error("Failed to load slides", err));
   }, []);
+
+  const heroProducts = slides
+    .map((s) => {
+      const p = s.product_details;
+      const imgSrc = getProductImage(p);
+      if (!imgSrc) return null;
+      return {
+        title: p?.name || "",
+        image: imgSrc,
+        discount: p?.get_discount_percentage || 0,
+      };
+    })
+    .filter(Boolean) as { title: string; image: string; discount: number }[];
 
 
   return (


### PR DESCRIPTION
## Summary
- restore logic for hero carousel product slides using `getProductImage`
- fix duplicate ID in header menu data to prevent key warnings

## Testing
- `npm run lint` *(fails: `next` not found)*