### PR TITLE
Use local placeholder image for products

### DIFF
--- a/frontend/public/images/no-image.svg
+++ b/frontend/public/images/no-image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#f0f0f0"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central" fill="#999" font-size="32" font-family="Arial, sans-serif">No Image</text>
+</svg>

--- a/frontend/src/components/Common/PreviewSlider.tsx
+++ b/frontend/src/components/Common/PreviewSlider.tsx
@@ -13,7 +13,7 @@ import { usePreviewSlider } from "@/app/context/PreviewSliderContext";
 import { useAppSelector } from "@/redux/store";
 import { ProductMediaItem } from "@/types/product"; // Import ProductMediaItem
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/770x500/eee/ccc?text=No+Image";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 
 const PreviewSliderModal = () => {

--- a/frontend/src/components/Common/ProductItem.tsx
+++ b/frontend/src/components/Common/ProductItem.tsx
@@ -17,7 +17,7 @@ import Link from "next/link";
 import { Heart, Eye, ShoppingCart } from 'lucide-react';
 import DiscountBadge from "./DiscountBadge";
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/250x250/F0F0F0/777777?text=No+Image";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 const ProductItem = ({ item }: { item: Product }) => {
   // ADD THIS CONSOLE.LOG

--- a/frontend/src/components/Common/QuickViewModal.tsx
+++ b/frontend/src/components/Common/QuickViewModal.tsx
@@ -15,7 +15,7 @@ import { getProductBySlug } from "@/lib/apiService";
 import { Star, Heart, ShoppingCart, XCircle, RefreshCw } from "lucide-react"; // Lucide icons
 import DiscountBadge from "@/components/Common/DiscountBadge";
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/600x400/eee/ccc?text=No+Image";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 const QuickViewModal = () => {
   const { isQuickViewModalOpen, closeModal, productSlug, setProductSlug: setContextProductSlug } =

--- a/frontend/src/components/Home/BestSeller/SingleItem.tsx
+++ b/frontend/src/components/Home/BestSeller/SingleItem.tsx
@@ -19,7 +19,7 @@ import { toast } from "react-toastify"; // For user feedback
 import { Heart, Eye, ShoppingCart } from 'lucide-react'; // Lucide icons
 import DiscountBadge from "@/components/Common/DiscountBadge";
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/280x280/F0F0F0/777777?text=Image+Not+Available";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 const SingleItem = ({ item }: { item: Product }) => {
   const { openModal, setProductSlug } = useQuickViewModalContext();

--- a/frontend/src/components/Home/Categories/SingleItem.tsx
+++ b/frontend/src/components/Home/Categories/SingleItem.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Category as CategoryType } from '@/types/product'; // Using the richer Category type
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/82x62/F2F3F8/3C50E0?text=No+Image";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 const SingleItem = ({ item }: { item: CategoryType }) => {
   const imageUrl = item.image_url || item.image || PLACEHOLDER_IMAGE_URL; // Use image_url or fallback to image

--- a/frontend/src/components/Orders/OrderDetails.tsx
+++ b/frontend/src/components/Orders/OrderDetails.tsx
@@ -8,7 +8,7 @@ interface OrderDetailsProps {
   orderItem: OrderType; // Renamed prop to 'order' for clarity
 }
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/60x60/F0F0F0/777777?text=N/A";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 
 const OrderDetails = ({ orderItem: order }: OrderDetailsProps) => {

--- a/frontend/src/components/Shop/SingleGridItem.tsx
+++ b/frontend/src/components/Shop/SingleGridItem.tsx
@@ -16,7 +16,7 @@ import Link from "next/link";
 import { Heart, Eye, ShoppingCart } from 'lucide-react';
 import DiscountBadge from "@/components/Common/DiscountBadge";
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/250x250/F0F0F0/777777?text=No+Image";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 // The component expects a prop named 'product' from its parent.
 // Internally, this 'product' prop is aliased to 'item'.

--- a/frontend/src/components/Shop/SingleListItem.tsx
+++ b/frontend/src/components/Shop/SingleListItem.tsx
@@ -19,7 +19,7 @@ import { toast } from "react-toastify"; // For user feedback
 import { Heart, Eye, ShoppingCart } from 'lucide-react'; // Lucide icons
 import DiscountBadge from "@/components/Common/DiscountBadge";
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/250x250/F0F0F0/777777?text=No+Image";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 // Component expects a prop named 'item'
 const SingleListItem = ({ item }: { item: Product }) => {

--- a/frontend/src/components/ShopDetails/index.tsx
+++ b/frontend/src/components/ShopDetails/index.tsx
@@ -22,7 +22,7 @@ import { getProductReviews, createProductReview } from "@/lib/apiService";
 import { Review } from "@/types/product";
 
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/600x400/eee/ccc?text=No+Image";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 interface ShopDetailsProps {
   product: Product;

--- a/frontend/src/components/Wishlist/SingleItem.tsx
+++ b/frontend/src/components/Wishlist/SingleItem.tsx
@@ -12,7 +12,7 @@ import DiscountBadge from "@/components/Common/DiscountBadge";
 import { toast } from 'react-toastify';
 // No need to import removeItemFromWishlistAction from Redux slice here if parent handles Redux state update
 
-const PLACEHOLDER_IMAGE_URL = "https://placehold.co/80x70/F0F0F0/777777?text=No+Image";
+const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 // Component now expects 'item' to be a Product and 'onRemoveSuccess' to take product ID
 const SingleItem = ({ item, onRemoveSuccess }: { item: Product; onRemoveSuccess: (productId: number) => void }) => {


### PR DESCRIPTION
## Summary
- add `no-image.svg` placeholder to frontend assets
- use the local placeholder for product thumbnails and previews

## Testing
- `npm run lint` *(fails: `next` not found)*
- `python -m py_compile $(git ls-files '*.py')`