### PR TITLE
Add cart persistence and order model tests

### DIFF
--- a/backend/carts/tests.py
+++ b/backend/carts/tests.py
@@ -1,3 +1,62 @@
-from django.test import TestCase
+from decimal import Decimal
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from shop.models import Brand, Category, Product
+from carts.models import CartItem
 
-# Create your tests here.
+
+User = get_user_model()
+
+
+class CartPersistenceTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="cartuser", password="pass1234")
+
+        self.brand = Brand.objects.create(name="BrandA")
+        self.category = Category.objects.create(name="Accessories")
+        self.product = Product.objects.create(
+            name="Widget",
+            category=self.category,
+            brand=self.brand,
+            price=Decimal("9.99"),
+        )
+
+    def authenticate(self):
+        response = self.client.post(
+            "/api/accounts/token/",
+            {"username": "cartuser", "password": "pass1234"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {response.data['access']}")
+
+    def test_items_remain_after_logout_and_login(self):
+        self.authenticate()
+
+        add_resp = self.client.post(
+            "/api/carts/add-item/",
+            {"product_id": self.product.id, "quantity": 2},
+            format="json",
+        )
+        self.assertEqual(add_resp.status_code, 201)
+
+        list_resp = self.client.get("/api/carts/")
+        self.assertEqual(list_resp.status_code, 200)
+        self.assertEqual(len(list_resp.data["items"]), 1)
+
+        # remove credentials to simulate logout
+        self.client.credentials()
+
+        # authenticate again as if logging back in
+        self.authenticate()
+
+        list_resp = self.client.get("/api/carts/")
+        self.assertEqual(list_resp.status_code, 200)
+        self.assertEqual(len(list_resp.data["items"]), 1)
+        item = list_resp.data["items"][0]
+        self.assertEqual(item["product_id"], self.product.id)
+        self.assertEqual(item["quantity"], 2)
+
+        # ensure item exists in database
+        cart_item = CartItem.objects.get(cart__user=self.user, product=self.product)
+        self.assertEqual(cart_item.quantity, 2)

--- a/backend/orders/tests.py
+++ b/backend/orders/tests.py
@@ -1,3 +1,59 @@
-from django.test import TestCase
+from decimal import Decimal
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from shop.models import Brand, Category, Product
+from orders.models import Order
 
-# Create your tests here.
+
+User = get_user_model()
+
+
+class OrderModelTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="orderuser", password="pass1234")
+
+        self.brand = Brand.objects.create(name="BrandB")
+        self.category = Category.objects.create(name="Gadgets")
+        self.product = Product.objects.create(
+            name="Gizmo",
+            category=self.category,
+            brand=self.brand,
+            price=Decimal("20.00"),
+        )
+
+    def authenticate(self):
+        response = self.client.post(
+            "/api/accounts/token/",
+            {"username": "orderuser", "password": "pass1234"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {response.data['access']}")
+
+    def test_create_order_and_items(self):
+        self.authenticate()
+
+        order_data = {
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john@example.com",
+            "street_address": "123 Street",
+            "postal_code": "12345",
+            "city": "Town",
+            "country": "Nowhere",
+            "items": [
+                {"product_id": self.product.id, "price": "20.00", "quantity": 3}
+            ],
+        }
+
+        response = self.client.post("/api/orders/", order_data, format="json")
+        self.assertEqual(response.status_code, 201)
+
+        order = Order.objects.get(id=response.data["id"])
+        self.assertEqual(order.user, self.user)
+        self.assertEqual(order.items.count(), 1)
+        item = order.items.first()
+        self.assertEqual(item.product, self.product)
+        self.assertEqual(item.quantity, 3)
+        self.assertEqual(item.price, Decimal("20.00"))
+


### PR DESCRIPTION
## Summary
- add regression tests for cart persistence across logins
- add tests covering order creation and storage

## Testing
- `python manage.py test carts orders` *(fails: Could not install dependencies)*