### PR TITLE
Update category filters

### DIFF
--- a/frontend/src/components/ShopWithSidebar/index.tsx
+++ b/frontend/src/components/ShopWithSidebar/index.tsx
@@ -9,7 +9,7 @@ import SingleListItem from "../Shop/SingleListItem";
 import CategoryDropdown from "./CategoryDropdown";
 import PriceDropdown from "./PriceDropdown";
 import GenderDropdown from "./GenderDropdown"; // Assuming this is for Brands
-import { getProducts, GetProductsParams, PaginatedResponse, getCategories } from "@/lib/apiService";
+import { getProducts, GetProductsParams, PaginatedResponse, getCategories, GetCategoriesParams } from "@/lib/apiService";
 import { LayoutGrid, List } from "lucide-react";
 import Breadcrumb from "../Common/Breadcrumb";
 
@@ -101,9 +101,16 @@ const ShopWithSidebarContent: React.FC = () => {
 
   useEffect(() => {
     const loadCategories = async () => {
-      setIsLoadingCategories(true); setCategoryError(null);
+      setIsLoadingCategories(true);
+      setCategoryError(null);
       try {
-        const fetchedCategories = await getCategories();
+        const fetchedCategories = await getCategories({
+          brand__slug: filters.brand__slug,
+          compatible_with__slug: filters.compatible_with__slug,
+          search: filters.search,
+          price__gte: filters.min_price,
+          price__lte: filters.max_price,
+        });
         setAllCategories(fetchedCategories || []);
       } catch (err: any) {
         setCategoryError(err.message || "Failed to load categories.");
@@ -113,7 +120,7 @@ const ShopWithSidebarContent: React.FC = () => {
       }
     };
     loadCategories();
-  }, []);
+  }, [filters.brand__slug, filters.compatible_with__slug, filters.search, filters.min_price, filters.max_price]);
 
   // This useEffect is responsible for fetching products when filters or currentPage change.
   // It now waits for `initialUrlFiltersApplied` to be true before the first "real" fetch based on filters.

--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -153,12 +153,27 @@ export const getProductBySlug = (slug: string): Promise<Product> => {
   return fetchWrapper<Product>(`${SHOP_BASE_URL}/products/${slug}/`);
 };
 
-export const getCategories = (): Promise<ProductCategoryType[]> => {
-    // Assuming the direct response is PaginatedResponse<ProductCategoryType>
-    // If it can sometimes be just ProductCategoryType[], the original logic was fine,
-    // but it's safer to expect a consistent paginated structure or handle both explicitly.
-    return fetchWrapper<PaginatedResponse<ProductCategoryType>>(`${SHOP_BASE_URL}/categories/?limit=100`) // Fetch more categories
-        .then(data => data.results || []); // Always expect results from a paginated response
+export interface GetCategoriesParams {
+  brand__slug?: string;
+  compatible_with__slug?: string;
+  search?: string;
+  price__gte?: number;
+  price__lte?: number;
+}
+
+export const getCategories = (params?: GetCategoriesParams): Promise<ProductCategoryType[]> => {
+  const queryParams = new URLSearchParams();
+  queryParams.append('limit', '100');
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        queryParams.append(key, String(value));
+      }
+    });
+  }
+  return fetchWrapper<PaginatedResponse<ProductCategoryType>>(
+    `${SHOP_BASE_URL}/categories/?${queryParams.toString()}`
+  ).then((data) => data.results || []);
 };
 
 export const getCategoryBySlug = (slug: string): Promise<ProductCategoryType> => {


### PR DESCRIPTION
## Summary
- reload categories whenever filters change
- allow optional filter params when fetching categories
- hide categories with no matching products on the backend

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: `next` not found)*
- `python backend/manage.py check` *(fails: `django` not installed)*