### PR TITLE
Improve grid view icons and responsive thumbnails

### DIFF
--- a/frontend/src/components/Shop/SingleGridItem.tsx
+++ b/frontend/src/components/Shop/SingleGridItem.tsx
@@ -19,8 +19,9 @@ import DiscountBadge from "@/components/Common/DiscountBadge";
 const PLACEHOLDER_IMAGE_URL = "/images/no-image.svg";
 
 // The component expects a prop named 'product' from its parent.
-// Internally, this 'product' prop is aliased to 'item'.
-const SingleGridItem = ({ product: item }: { product: Product }) => {
+// Internally, this 'product' prop is aliased to 'item'. Optionally accepts
+// a `gridSize` to adapt thumbnail dimensions.
+const SingleGridItem = ({ product: item, gridSize = 3 }: { product: Product; gridSize?: number }) => {
   // ADD THIS GUARD AT THE TOP
   if (!item || typeof item.id === 'undefined') {
     // Optionally log this occurrence to help debug why an invalid item is being passed
@@ -100,6 +101,7 @@ const SingleGridItem = ({ product: item }: { product: Product }) => {
 
   // These calculations should now be safe due to the guard at the top
   const imageUrl = item.cover_image_url || item.imgs?.previews?.[0] || PLACEHOLDER_IMAGE_URL;
+  const imageDimension = gridSize === 4 ? 150 : gridSize === 2 ? 300 : 220;
   const rating = item.average_rating ? parseFloat(String(item.average_rating)) : 0;
   const reviewCount = typeof item.reviews_count === 'number' ? item.reviews_count : 0;
 
@@ -134,8 +136,8 @@ const SingleGridItem = ({ product: item }: { product: Product }) => {
           <Image
             src={imageUrl}
             alt={item.name || "Product image"}
-            width={250}
-            height={250}
+            width={imageDimension}
+            height={imageDimension}
             className="object-contain w-full h-full group-hover:scale-105 transition-transform duration-300 ease-in-out"
             onError={(e) => {
               (e.target as HTMLImageElement).onerror = null;

--- a/frontend/src/components/ShopWithSidebar/index.tsx
+++ b/frontend/src/components/ShopWithSidebar/index.tsx
@@ -176,11 +176,11 @@ const ShopWithSidebarContent: React.FC = () => {
 
   const uniqueBrandNames = Array.from(new Set(products.map(p => p.brand_details?.name).filter(Boolean))) as string[];
 
-  const gridColsClass = gridSize === 4
-    ? "sm:grid-cols-2 xl:grid-cols-4"
-    : gridSize === 2
-    ? "sm:grid-cols-2 xl:grid-cols-2"
-    : "sm:grid-cols-2 xl:grid-cols-3";
+  const gridColsClass = gridSize === 2
+    ? "sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2"
+    : gridSize === 4
+    ? "sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-4"
+    : "sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-3";
 
   const renderPagination = () => { /* ... keep your existing pagination logic ... */
     if (totalPages <= 1) return null;
@@ -232,18 +232,32 @@ const ShopWithSidebarContent: React.FC = () => {
                     <button onClick={() => setViewMode("grid")} className={`p-2 rounded-md ${viewMode === "grid" ? "bg-indigo-600 text-white" : "bg-gray-200 text-gray-700 hover:bg-gray-300"}`} aria-label="Grid view"><LayoutGrid size={20} /></button>
                     <button onClick={() => setViewMode("list")} className={`p-2 rounded-md ${viewMode === "list" ? "bg-indigo-600 text-white" : "bg-gray-200 text-gray-700 hover:bg-gray-300"}`} aria-label="List view"><List size={20} /></button>
                     </div>
-                    <div className="flex items-center ml-4">
-                      <label htmlFor="gridSize" className="mr-2 text-sm text-gray-700 shrink-0">Grid:</label>
-                      <select
-                        id="gridSize"
-                        value={gridSize}
-                        onChange={(e) => handleGridSizeChange(parseInt(e.target.value))}
-                        className="block rounded-md border-gray-300 py-1.5 pl-3 pr-3 text-gray-900 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6 shadow-sm"
-                      >
-                        <option value={2}>2 x 2</option>
-                        <option value={3}>3 x 3</option>
-                        <option value={4}>4 x 4</option>
-                      </select>
+                    <div className="flex items-center ml-4 space-x-1">
+                      {[2, 3, 4].map((size) => (
+                        <button
+                          key={size}
+                          onClick={() => handleGridSizeChange(size)}
+                          aria-label={`Grid ${size}x${size}`}
+                          className={`p-1 border rounded-md flex items-center justify-center w-8 h-8 ${
+                            gridSize === size
+                              ? "bg-indigo-600 text-white border-indigo-600"
+                              : "bg-gray-200 text-gray-700 border-gray-300 hover:bg-gray-300"
+                          }`}
+                        >
+                          <span
+                            className="grid gap-[1px]"
+                            style={{
+                              gridTemplateColumns: `repeat(${size}, 1fr)`,
+                              width: "14px",
+                              height: "14px",
+                            }}
+                          >
+                            {Array.from({ length: size * size }).map((_, i) => (
+                              <span key={i} className="block w-full h-full bg-current"></span>
+                            ))}
+                          </span>
+                        </button>
+                      ))}
                     </div>
                 </div>
               </div>
@@ -254,8 +268,14 @@ const ShopWithSidebarContent: React.FC = () => {
               {!isLoading && !error && products.length > 0 && (
                 <>
                   {viewMode === "grid" ? (
-                    <div className={`grid grid-cols-1 gap-6 ${gridColsClass}`}>
-                      {products.map((product, index) => (!product || typeof product.id === 'undefined' ? <div key={`invalid-grid-${index}`} className="text-red-500 p-2 border border-red-300">Invalid product data</div> : <SingleGridItem key={product.id || `grid-fallback-${index}`} product={product} /> ))}
+                    <div className={`grid grid-cols-1 gap-6 ${gridColsClass}`}> 
+                      {products.map((product, index) => (
+                        !product || typeof product.id === 'undefined' ? (
+                          <div key={`invalid-grid-${index}`} className="text-red-500 p-2 border border-red-300">Invalid product data</div>
+                        ) : (
+                          <SingleGridItem key={product.id || `grid-fallback-${index}`} product={product} gridSize={gridSize} />
+                        )
+                      ))}
                     </div>
                   ) : (
                     <div className="space-y-6">

--- a/frontend/src/components/ShopWithoutSidebar/index.tsx
+++ b/frontend/src/components/ShopWithoutSidebar/index.tsx
@@ -131,7 +131,7 @@ const ShopWithoutSidebar = () => {
               >
                 {shopData.map((item, key) =>
                   productStyle === "grid" ? (
-                    <SingleGridItem item={item} key={key} />
+                    <SingleGridItem product={item} gridSize={4} key={key} />
                   ) : (
                     <SingleListItem item={item} key={key} />
                   )


### PR DESCRIPTION
## Summary
- tweak `ShopWithSidebar` grid logic for more responsive columns
- replace grid size dropdown with icon buttons
- allow `SingleGridItem` to size images based on selected grid
- adjust `ShopWithoutSidebar` to pass grid size

## Testing
- `npm run lint` *(fails: next not found)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*