### PR TITLE
Add operations workflow pages

### DIFF
--- a/frontend/src/app/(site)/(pages)/driver-settlement/page.tsx
+++ b/frontend/src/app/(site)/(pages)/driver-settlement/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Driver Settlement",
+  description: "Settlement details for drivers",
+};
+
+const DriverSettlementPage = () => {
+  return (
+    <main className="max-w-[1170px] mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Driver Settlement</h1>
+      <p>This page will cover driver settlement information.</p>
+    </main>
+  );
+};
+
+export default DriverSettlementPage;

--- a/frontend/src/app/(site)/(pages)/orders/page.tsx
+++ b/frontend/src/app/(site)/(pages)/orders/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Orders",
+  description: "List of orders",
+};
+
+const OrdersPage = () => {
+  return (
+    <main className="max-w-[1170px] mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Orders</h1>
+      <p>This page will show order workflow information.</p>
+    </main>
+  );
+};
+
+export default OrdersPage;

--- a/frontend/src/app/(site)/(pages)/trips/page.tsx
+++ b/frontend/src/app/(site)/(pages)/trips/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Trips",
+  description: "List of trips",
+};
+
+const TripsPage = () => {
+  return (
+    <main className="max-w-[1170px] mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Trips</h1>
+      <p>This page will display trip information.</p>
+    </main>
+  );
+};
+
+export default TripsPage;

--- a/frontend/src/components/Header/menuData.ts
+++ b/frontend/src/components/Header/menuData.ts
@@ -125,4 +125,30 @@ export const menuData: Menu[] = [
       },
     ],
   },
+  {
+    id: 8,
+    title: "Operations",
+    newTab: false,
+    path: "/",
+    submenu: [
+      {
+        id: 81,
+        title: "Orders",
+        newTab: false,
+        path: "/orders",
+      },
+      {
+        id: 82,
+        title: "Trips",
+        newTab: false,
+        path: "/trips",
+      },
+      {
+        id: 83,
+        title: "Driver Settlement",
+        newTab: false,
+        path: "/driver-settlement",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- add an Operations menu section with Orders, Trips, and Driver Settlement links
- create placeholder pages for Orders, Trips and Driver Settlement

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*