### PR TITLE
Fix missing div closing in AccountDashboard

### DIFF
--- a/frontend/src/components/AccountDashboard.jsx
+++ b/frontend/src/components/AccountDashboard.jsx
@@ -440,6 +440,7 @@ const handleLogout = () => {
             </div>
           </div>
         </div>
+        </div>
       </section>
       {isAddressModalOpen && (
         <AddressModal


### PR DESCRIPTION
## Summary
- close an unclosed `<div>` in `AccountDashboard.jsx`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d7c19cf483208373490313459821