### PR TITLE
Fix breadcrumb path in AccountDashboard

### DIFF
--- a/frontend/src/components/AccountDashboard.jsx
+++ b/frontend/src/components/AccountDashboard.jsx
@@ -1,7 +1,7 @@
 // src/components/AccountDashboard.jsx
 "use client";
 import React, { useState, useEffect } from "react";
-import Breadcrumb from "../Common/Breadcrumb";
+import Breadcrumb from "./Common/Breadcrumb";
 import Image from "next/image";
 import AddressModal from "./AddressModal";
 import Orders from "../Orders"; // Ensure Orders component is correctly implemented


### PR DESCRIPTION
## Summary
- correct Breadcrumb import path in `AccountDashboard.jsx`

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e5d5ea088320a6fca2e1b48ef6fa