### PR TITLE
Fix missing type for paginated product results

### DIFF
--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -189,3 +189,11 @@ export type CartItem = {
     previews: string[];
   };
 };
+
+// Paginated product response used throughout the frontend
+export interface PaginatedProducts {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Product[];
+}


### PR DESCRIPTION
## Summary
- define `PaginatedProducts` interface in product types

## Testing
- `python backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684a013289dc8320abfe314717cd6657