### PR TITLE
Remove operations menu and adjust layout padding

### DIFF
--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
                 <QuickViewModalProvider>
                   <PreviewSliderProvider>
                     <HeaderWithSuspense />
-                    <main className="pt-24 md:pt-28 xl:pt-36">
+                    <main className="pt-28 md:pt-32 xl:pt-40">
                       {children}
                     </main>
                     <QuickViewModal />

--- a/frontend/src/components/Header/menuData.ts
+++ b/frontend/src/components/Header/menuData.ts
@@ -125,30 +125,4 @@ export const menuData: Menu[] = [
       },
     ],
   },
-  {
-    id: 8,
-    title: "Operations",
-    newTab: false,
-    path: "/",
-    submenu: [
-      {
-        id: 81,
-        title: "Orders",
-        newTab: false,
-        path: "/orders",
-      },
-      {
-        id: 82,
-        title: "Trips",
-        newTab: false,
-        path: "/trips",
-      },
-      {
-        id: 83,
-        title: "Driver Settlement",
-        newTab: false,
-        path: "/driver-settlement",
-      },
-    ],
-  },
 ];


### PR DESCRIPTION
## Summary
- remove Operations item from navigation menu
- increase main layout top padding for more spacing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a69cb5a08320bd580631cc2a7553