### PR TITLE
Add deployment instructions and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,43 @@ update `NEXT_PUBLIC_API_BASE_URL` in `frontend/.env.local` with your computer's
 IP address and ensure the backend is started with `0.0.0.0:8000` as shown above.
 
 With both servers running you can explore the e‑commerce site locally.
+
+## Deployment
+
+### Backend on PythonAnywhere
+1. Create an account on [PythonAnywhere](https://www.pythonanywhere.com/) and add a new **Manual configuration** web app using the same Python version as your local environment.
+2. Clone this repository on your PythonAnywhere account:
+   ```bash
+   git clone <REPOSITORY_URL> ~/my_estore
+   cd ~/my_estore
+   ```
+3. Create a virtual environment and install the dependencies:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+4. Copy `backend/.env.example` to `backend/.env` and adjust values such as `SECRET_KEY`.
+5. Run the database migrations and collect static files:
+   ```bash
+   cd backend
+   python manage.py migrate
+   python manage.py collectstatic
+   ```
+6. In the **Web** tab set:
+   - **Working directory:** `/home/<username>/my_estore/backend`
+   - **WSGI file:** `/home/<username>/my_estore/backend/backend/wsgi.py`
+   - Map `/static/` to `/home/<username>/my_estore/backend/staticfiles`
+   - Map `/media/` to `/home/<username>/my_estore/backend/media`
+7. Reload the web app. Your API will be served from `https://<username>.pythonanywhere.com/`.
+
+### Frontend on Netlify
+1. On Netlify, create a new site from Git and choose this repository.
+2. Set the **Base directory** to `frontend`.
+3. Use `npm run build` as the build command and `.next` as the publish directory.
+4. Define the environment variable `NEXT_PUBLIC_API_BASE_URL` with the full URL of your PythonAnywhere backend, for example:
+   ```
+   NEXT_PUBLIC_API_BASE_URL=https://<username>.pythonanywhere.com/api
+   ```
+   If you use Next.js image optimization also set `NEXT_PUBLIC_BACKEND_HOST=<username>.pythonanywhere.com`.
+5. Deploy the site. Netlify will build the frontend and host it at your chosen domain.

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -149,7 +149,7 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = '/static/'
-# STATIC_ROOT = BASE_DIR / 'staticfiles' # For production 'collectstatic'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 # STATICFILES_DIRS = [BASE_DIR / 'static'] # For development static files outside apps
 
 # Media files (User-uploaded content like product images)

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,4 @@
 # Example frontend environment configuration
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api
+# Uncomment and set this in production if you host the backend elsewhere
+# NEXT_PUBLIC_BACKEND_HOST=yourusername.pythonanywhere.com

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,23 +1,28 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true, // Or your existing config
+  reactStrictMode: true,
   images: {
     remotePatterns: [
       {
-        protocol: 'http', // Or 'https' if your local Django serves over HTTPS
+        protocol: 'http',
         hostname: 'localhost',
-        port: '8000', // Specify the port your Django backend is using for media
-        pathname: '/media/**', // Be more specific if all your media is under /media/
+        port: '8000',
+        pathname: '/media/**',
       },
       {
-        protocol: 'https', // For the placeholder images
+        protocol: 'https',
         hostname: 'placehold.co',
-        // port: '', // Default port for https is 443
-        // pathname: '/**', // Allow all paths from this placeholder domain
       },
-      // You can add other hostnames here if needed in the future
     ],
   },
 };
+
+if (process.env.NEXT_PUBLIC_BACKEND_HOST) {
+  nextConfig.images.remotePatterns.push({
+    protocol: 'https',
+    hostname: process.env.NEXT_PUBLIC_BACKEND_HOST,
+    pathname: '/media/**',
+  });
+}
 
 module.exports = nextConfig;

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  base = "frontend"
+  command = "npm run build"
+  publish = ".next"
+
+[[plugins]]
+  package = "@netlify/next-runtime"


### PR DESCRIPTION
## Summary
- update Django settings with STATIC_ROOT
- allow production image host configuration in Next.js
- document deployment to PythonAnywhere and Netlify
- provide example backend host env variable
- add Netlify configuration

## Testing
- `python -m py_compile backend/backend/settings.py`
- `python -m py_compile backend/manage.py`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851aaa1c8f88320aee8abad3675a60c