### PR TITLE
Add setup helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@ __pycache__/
 # Node modules
 frontend/node_modules/
 frontend/.env.local
+
+# Virtual environments
+venv/
+.venv/
+
+# Local database and media files
+backend/db.sqlite3
+backend/media/
+backend/staticfiles/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ from GitHub.
 
 ## Quick start
 
+The repository includes a helper script `setup_local.sh` that automates the
+most common steps. After cloning the repo simply run:
+
+```bash
+./setup_local.sh
+```
+
+The script creates a Python virtual environment, installs backend dependencies,
+sets up the example environment files, runs migrations and installs the frontend
+packages. Afterwards you can start the backend and frontend servers manually as
+shown below.
+
 ### 1. Clone the repository
 ```bash
 git clone <REPOSITORY_URL>

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Simple helper script to set up and start the development environment.
+set -e
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "venv" ]; then
+  python -m venv venv
+fi
+
+source venv/bin/activate
+pip install -r requirements.txt
+
+# Copy backend environment file if missing
+if [ ! -f backend/.env ]; then
+  cp backend/.env.example backend/.env
+fi
+
+# Run migrations
+python backend/manage.py migrate
+
+# Install frontend dependencies
+pushd frontend >/dev/null
+npm install
+if [ ! -f .env.local ]; then
+  cp .env.local.example .env.local
+fi
+popd >/dev/null
+
+echo "Setup complete. To start the servers run:\n"
+echo "  source venv/bin/activate && python backend/manage.py runserver 0.0.0.0:8000"
+echo "  cd frontend && npm run dev"


### PR DESCRIPTION
## Summary
- ignore common local development files
- document `setup_local.sh` in README
- add a script to setup backend and frontend dependencies

## Testing
- `pytest` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b030d198832097665863f8b23f65