### PR TITLE
Fix Netlify build config by adding plugin dep

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "tailwindcss": "3.3.3"
   },
   "devDependencies": {
+    "@netlify/next-runtime": "latest",
     "@types/node": "20.6.2",
     "@types/react": "19.0.12",
     "@types/react-dom": "19.0.4",


### PR DESCRIPTION
## Summary
- add `@netlify/next-runtime` to the frontend dev dependencies

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff00177c83209bec957b0c2a11e1