### PR TITLE
Fix Netlify build path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
-  command = "npm --prefix frontend run build"
-  publish = "frontend/.next"
+  base = "frontend"
+  command = "npm run build"
+  publish = ".next"
 
 [[plugins]]
   package = "@netlify/next-runtime"


### PR DESCRIPTION
## Summary
- ensure Netlify looks in the frontend directory

## Testing
- `pytest -q` *(fails: no tests ran)*
- `python manage.py test` *(fails: Django not installed)*
- `pip install -r requirements.txt` *(fails due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685200969b1883208bfc41b5a5a7975b