### PR TITLE
Fix PageProps typing for product details page

### DIFF
--- a/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
@@ -3,14 +3,12 @@ import React from 'react';
 import ShopDetailsComponent from '@/components/ShopDetails'; // Assuming your main component is named ShopDetails
 import { getProductBySlug } from '@/lib/apiService';
 import { Product } from '@/types/product';
-import { Metadata, ResolvingMetadata } from 'next';
+import { Metadata, ResolvingMetadata, type PageProps } from 'next';
 import APITestComponent from '@/components/Common/APITestComponent'; // For easy debugging
 
-interface ProductDetailsPageProps {
-  params: {
-    slug: string;
-  };
-}
+type ProductDetailsPageProps = PageProps<{
+  slug: string;
+}>;
 
 // Function to generate metadata dynamically
 export async function generateMetadata(

--- a/frontend/src/app/(site)/(pages)/shop-details/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/page.tsx
@@ -1,11 +1,10 @@
 // src/app/(site)/(pages)/shop-details/[slug]/page.tsx
 import React from 'react';
+import type { PageProps } from 'next';
 
-interface ProductDetailsPageProps {
-  params: {
-    slug: string;
-  };
-}
+type ProductDetailsPageProps = PageProps<{
+  slug: string;
+}>;
 
 export default function TemporaryProductDetailsPage({ params }: ProductDetailsPageProps) {
   return (


### PR DESCRIPTION
## Summary
- align dynamic product details page types with Next.js
- update temporary shop details page to use Next's PageProps

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68520b00eca8832085ab7ac33240e66d