### PR TITLE
Fix type error in ShopDetails page

### DIFF
--- a/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import ShopDetailsComponent from '@/components/ShopDetails'; // Assuming your main component is named ShopDetails
 import { getProductBySlug } from '@/lib/apiService';
 import { Product } from '@/types/product';
-import { Metadata, ResolvingMetadata, type PageProps } from 'next';
+import { Metadata, ResolvingMetadata } from 'next';
 import APITestComponent from '@/components/Common/APITestComponent'; // For easy debugging
 
-type ProductDetailsPageProps = PageProps<{
-  slug: string;
-}>;
+interface ProductDetailsPageProps {
+  params: {
+    slug: string;
+  };
+}
 
 // Function to generate metadata dynamically
 export async function generateMetadata(


### PR DESCRIPTION
## Summary
- define `ProductDetailsPageProps` interface locally to avoid missing `next` export

## Testing
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520f8615248320a6e3e82fea4ec33f