### PR TITLE
Fix PageProps type for dynamic slug page

### DIFF
--- a/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
@@ -3,14 +3,12 @@ import React from 'react';
 import ShopDetailsComponent from '@/components/ShopDetails'; // Assuming your main component is named ShopDetails
 import { getProductBySlug } from '@/lib/apiService';
 import { Product } from '@/types/product';
-import { Metadata, ResolvingMetadata } from 'next';
+import type { PageProps, Metadata, ResolvingMetadata } from 'next';
 import APITestComponent from '@/components/Common/APITestComponent'; // For easy debugging
 
-interface ProductDetailsPageProps {
-  params: {
-    slug: string;
-  };
-}
+type ProductDetailsPageProps = PageProps<{
+  slug: string;
+}>;
 
 // Function to generate metadata dynamically
 export async function generateMetadata(


### PR DESCRIPTION
## Summary
- use `PageProps` from Next.js for product details page

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68521251892483208dd817ccfe72d7b4