### PR TITLE
Fix PageProps import

### DIFF
--- a/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import ShopDetailsComponent from '@/components/ShopDetails'; // Assuming your main component is named ShopDetails
 import { getProductBySlug } from '@/lib/apiService';
 import { Product } from '@/types/product';
-import type { PageProps, Metadata, ResolvingMetadata } from 'next';
+import type { Metadata, ResolvingMetadata } from 'next';
 import APITestComponent from '@/components/Common/APITestComponent'; // For easy debugging
 
-type ProductDetailsPageProps = PageProps<{
-  slug: string;
-}>;
+type ProductDetailsPageProps = {
+  params: {
+    slug: string;
+  };
+};
 
 // Function to generate metadata dynamically
 export async function generateMetadata(

--- a/frontend/src/app/(site)/(pages)/shop-details/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/page.tsx
@@ -1,10 +1,12 @@
 // src/app/(site)/(pages)/shop-details/[slug]/page.tsx
 import React from 'react';
-import type { PageProps } from 'next';
+// Page route parameters are passed via the `params` prop
 
-type ProductDetailsPageProps = PageProps<{
-  slug: string;
-}>;
+type ProductDetailsPageProps = {
+  params: {
+    slug: string;
+  };
+};
 
 export default function TemporaryProductDetailsPage({ params }: ProductDetailsPageProps) {
   return (


### PR DESCRIPTION
## Summary
- remove `PageProps` import because it's not exported from `next`
- adjust page prop types for shop details pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685214ee684083209974c64c9355651a