### PR TITLE
Fix Next.js type props for product page

### DIFF
--- a/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
@@ -3,14 +3,12 @@ import React from 'react';
 import ShopDetailsComponent from '@/components/ShopDetails'; // Assuming your main component is named ShopDetails
 import { getProductBySlug } from '@/lib/apiService';
 import { Product } from '@/types/product';
-import type { Metadata, ResolvingMetadata } from 'next';
+import type { Metadata, ResolvingMetadata, PageProps } from 'next';
 import APITestComponent from '@/components/Common/APITestComponent'; // For easy debugging
 
-type ProductDetailsPageProps = {
-  params: {
-    slug: string;
-  };
-};
+type ProductDetailsPageProps = PageProps<{
+  slug: string;
+}>;
 
 // Function to generate metadata dynamically
 export async function generateMetadata(


### PR DESCRIPTION
## Summary
- correct prop typing for dynamic product page

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852211c21fc832094b662e73ffa32e5