### PR TITLE
Fix ProductDetailsPageProps type

### DIFF
--- a/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import ShopDetailsComponent from '@/components/ShopDetails'; // Assuming your main component is named ShopDetails
 import { getProductBySlug } from '@/lib/apiService';
 import { Product } from '@/types/product';
-import type { Metadata, ResolvingMetadata, PageProps } from 'next';
+import type { Metadata, ResolvingMetadata } from 'next';
 import APITestComponent from '@/components/Common/APITestComponent'; // For easy debugging
 
-type ProductDetailsPageProps = PageProps<{
-  slug: string;
-}>;
+type ProductDetailsPageProps = {
+  params: {
+    slug: string;
+  };
+};
 
 // Function to generate metadata dynamically
 export async function generateMetadata(


### PR DESCRIPTION
## Summary
- correct `ProductDetailsPageProps` so its `params` shape matches Next.js expectations

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522dafbb948320a640d66b507c879e