### PR TITLE
Fix ProductDetailsPageProps type definition

### DIFF
--- a/frontend/src/app/(site)/(pages)/shop-details/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/page.tsx
@@ -2,11 +2,11 @@
 import React from 'react';
 // Page route parameters are passed via the `params` prop
 
-type ProductDetailsPageProps = {
-  params: {
-    slug: string;
-  };
-};
+import type { PageProps } from 'next';
+
+type ProductDetailsPageProps = PageProps<{
+  slug: string;
+}>;
 
 export default function TemporaryProductDetailsPage({ params }: ProductDetailsPageProps) {
   return (


### PR DESCRIPTION
## Summary
- correct ProductDetailsPageProps to use `PageProps` in `/shop-details/page.tsx`

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852c7b2b9988320801b91efe97f9758