### PR TITLE
Fix duplicate React keys in menu

### DIFF
--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -51,13 +51,16 @@ const Header = () => {
     ? headerMenuDataImport.filter(item => item && typeof item.title !== 'undefined')
     : [];
 
+  // Offset brand and model IDs to avoid collisions with the static menu items
+  // that are defined in `menuData`. Without unique IDs React may log warnings
+  // about duplicate keys when rendering the combined menu.
   const brandMenuItems: MenuType[] = brands.map((brand) => ({
-    id: brand.id,
+    id: brand.id + 1000,
     title: brand.name,
     newTab: false,
     path: `/shop-with-sidebar?brand__slug=${brand.slug}`,
     submenu: (brand.phone_models || []).map((model) => ({
-      id: model.id,
+      id: model.id + 100000,
       title: model.name,
       newTab: false,
       path: `/shop-with-sidebar?compatible_with__slug=${model.slug}`,


### PR DESCRIPTION
## Summary
- avoid duplicate keys when merging header menu with dynamic brand items

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d3cb23708320aff42d3f6413bc07