### PR TITLE
Fix stray zero overlay on product thumbnails

### DIFF
--- a/frontend/src/components/Common/ProductItem.tsx
+++ b/frontend/src/components/Common/ProductItem.tsx
@@ -154,8 +154,11 @@ const ProductItem = ({ item }: { item: Product }) => {
             priority={false} // Generally false for list items, true for LCP images
           />
         </Link>
-        {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-          <DiscountBadge percentage={item.get_discount_percentage} className="absolute top-3 right-3" />
+        {Number(item.get_discount_percentage) > 0 && (
+          <DiscountBadge
+            percentage={Number(item.get_discount_percentage)}
+            className="absolute top-3 right-3"
+          />
         )}
         {!item.is_available && (
           <span className="absolute top-3 left-3 bg-gray-700 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
@@ -219,7 +222,9 @@ const ProductItem = ({ item }: { item: Product }) => {
             </span>
           ) : (
             <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded">
-              {item.get_discount_percentage && item.get_discount_percentage > 0 ? `${item.get_discount_percentage}% OFF` : 'Login to see price'}
+              {Number(item.get_discount_percentage) > 0
+                ? `${item.get_discount_percentage}% OFF`
+                : 'Login to see price'}
             </span>
           )}
           {!item.is_available && (

--- a/frontend/src/components/Common/QuickViewModal.tsx
+++ b/frontend/src/components/Common/QuickViewModal.tsx
@@ -282,13 +282,16 @@ const QuickViewModal = () => {
                       ${currentPrice.toFixed(2)}
                     </span>
                   )}
-                  {product.get_discount_percentage && product.get_discount_percentage > 0 && (
-                    <DiscountBadge percentage={product.get_discount_percentage} className="ml-2" />
+                  {Number(product.get_discount_percentage) > 0 && (
+                    <DiscountBadge
+                      percentage={Number(product.get_discount_percentage)}
+                      className="ml-2"
+                    />
                   )}
                 </>
               ) : (
                 <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded">
-                  {product.get_discount_percentage && product.get_discount_percentage > 0
+                  {Number(product.get_discount_percentage) > 0
                     ? `${product.get_discount_percentage}% OFF`
                     : 'Login to see price'}
                 </span>

--- a/frontend/src/components/Home/BestSeller/SingleItem.tsx
+++ b/frontend/src/components/Home/BestSeller/SingleItem.tsx
@@ -145,8 +145,11 @@ const SingleItem = ({ item }: { item: Product }) => {
             }}
           />
         </Link>
-        {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-          <DiscountBadge percentage={item.get_discount_percentage} className="absolute top-3 right-3" />
+        {Number(item.get_discount_percentage) > 0 && (
+          <DiscountBadge
+            percentage={Number(item.get_discount_percentage)}
+            className="absolute top-3 right-3"
+          />
         )}
          {!item.is_available && (
           <span className="absolute top-3 left-3 bg-gray-700 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
@@ -211,7 +214,9 @@ const SingleItem = ({ item }: { item: Product }) => {
             </span>
           ) : (
             <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded">
-              {item.get_discount_percentage && item.get_discount_percentage > 0 ? `${item.get_discount_percentage}% OFF` : 'Login to see price'}
+              {Number(item.get_discount_percentage) > 0
+                ? `${item.get_discount_percentage}% OFF`
+                : 'Login to see price'}
             </span>
           )}
           {!item.is_available && (

--- a/frontend/src/components/Shop/SingleGridItem.tsx
+++ b/frontend/src/components/Shop/SingleGridItem.tsx
@@ -144,8 +144,11 @@ const SingleGridItem = ({ product: item, gridSize = 3 }: { product: Product; gri
             }}
           />
         </Link>
-        {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-          <DiscountBadge percentage={item.get_discount_percentage} className="absolute top-3 right-3" />
+        {Number(item.get_discount_percentage) > 0 && (
+          <DiscountBadge
+            percentage={Number(item.get_discount_percentage)}
+            className="absolute top-3 right-3"
+          />
         )}
         {!item.is_available && (
           <span className="absolute top-3 left-3 bg-gray-700 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
@@ -215,13 +218,13 @@ const SingleGridItem = ({ product: item, gridSize = 3 }: { product: Product; gri
               {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
                 <span className="text-gray-500 line-through text-sm">${currentPrice.toFixed(2)}</span>
               )}
-              {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-                <DiscountBadge percentage={item.get_discount_percentage} className="ml-1" />
+              {Number(item.get_discount_percentage) > 0 && (
+                <DiscountBadge percentage={Number(item.get_discount_percentage)} className="ml-1" />
               )}
             </span>
           ) : (
             <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded">
-              {item.get_discount_percentage && item.get_discount_percentage > 0
+              {Number(item.get_discount_percentage) > 0
                 ? `${item.get_discount_percentage}% OFF`
                 : 'Login to see price'}
             </span>

--- a/frontend/src/components/Shop/SingleListItem.tsx
+++ b/frontend/src/components/Shop/SingleListItem.tsx
@@ -151,8 +151,11 @@ const SingleListItem = ({ item }: { item: Product }) => {
               }}
             />
           </Link>
-           {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-            <DiscountBadge percentage={item.get_discount_percentage} className="absolute top-3 right-3" />
+           {Number(item.get_discount_percentage) > 0 && (
+            <DiscountBadge
+              percentage={Number(item.get_discount_percentage)}
+              className="absolute top-3 right-3"
+            />
             )}
             {!item.is_available && (
             <span className="absolute top-3 left-3 bg-gray-700 text-white text-xs font-semibold px-2 py-1 rounded-md shadow-sm">
@@ -192,13 +195,13 @@ const SingleListItem = ({ item }: { item: Product }) => {
                 {currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (
                   <span className="text-gray-500 line-through text-base">${currentPrice.toFixed(2)}</span>
                 )}
-                {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-                  <DiscountBadge percentage={item.get_discount_percentage} className="ml-1" />
+                {Number(item.get_discount_percentage) > 0 && (
+                  <DiscountBadge percentage={Number(item.get_discount_percentage)} className="ml-1" />
                 )}
               </span>
             ) : (
               <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded mb-3">
-                {item.get_discount_percentage && item.get_discount_percentage > 0
+                {Number(item.get_discount_percentage) > 0
                   ? `${item.get_discount_percentage}% OFF`
                   : 'Login to see price'}
               </span>

--- a/frontend/src/components/ShopDetails/index.tsx
+++ b/frontend/src/components/ShopDetails/index.tsx
@@ -246,8 +246,8 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
                 <h2 className="font-semibold text-xl sm:text-2xl xl:text-custom-3 text-dark dark:text-white">
                   {product.name || "Product Name"}
                 </h2>
-                {product.get_discount_percentage != null && product.get_discount_percentage > 0 && (
-                    <DiscountBadge percentage={product.get_discount_percentage} className="ml-2" />
+                {Number(product.get_discount_percentage) > 0 && (
+                    <DiscountBadge percentage={Number(product.get_discount_percentage)} className="ml-2" />
                 )}
               </div>
 
@@ -285,13 +285,13 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
                         ${Number(product.price).toFixed(2)}
                       </span>
                     )}
-                    {product.get_discount_percentage != null && product.get_discount_percentage > 0 && (
-                      <DiscountBadge percentage={product.get_discount_percentage} className="ml-2" />
+                    {Number(product.get_discount_percentage) > 0 && (
+                      <DiscountBadge percentage={Number(product.get_discount_percentage)} className="ml-2" />
                     )}
                   </>
                 ) : (
                   <span className="inline-block font-semibold text-red-600 bg-red-50 px-2 py-1 rounded">
-                    {product.get_discount_percentage && product.get_discount_percentage > 0
+                    {Number(product.get_discount_percentage) > 0
                       ? `${product.get_discount_percentage}% OFF`
                       : 'Login to see price'}
                   </span>

--- a/frontend/src/components/Wishlist/SingleItem.tsx
+++ b/frontend/src/components/Wishlist/SingleItem.tsx
@@ -128,12 +128,12 @@ const SingleItem = ({ item, onRemoveSuccess }: { item: Product; onRemoveSuccess:
         {isAuthenticated ? (
           <p className="text-dark dark:text-white font-medium flex items-center justify-center gap-1">
             ${effectivePrice.toFixed(2)}
-            {item.get_discount_percentage && item.get_discount_percentage > 0 && (
-              <DiscountBadge percentage={item.get_discount_percentage} />
+            {Number(item.get_discount_percentage) > 0 && (
+              <DiscountBadge percentage={Number(item.get_discount_percentage)} />
             )}
           </p>
         ) : (
-          <p className="font-semibold text-red-600">{item.get_discount_percentage && item.get_discount_percentage > 0 ? `${item.get_discount_percentage}% OFF` : 'Login to see price'}</p>
+          <p className="font-semibold text-red-600">{Number(item.get_discount_percentage) > 0 ? `${item.get_discount_percentage}% OFF` : 'Login to see price'}</p>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- ensure discount badge only renders when discount percentage is greater than zero
- update checks across product cards, wishlist, quick view, and details views

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd424f7c83208505fd13dfb0adc9