### PR TITLE
Add WhiteNoise integration

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'whitenoise.runserver_nostatic',
     'rest_framework',
     'corsheaders',
     'shop.apps.ShopConfig',
@@ -54,6 +55,7 @@ AUTH_USER_MODEL = 'accounts.User'
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',  # CORS middleware, place it high
     'django.middleware.common.CommonMiddleware',
@@ -150,6 +152,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = '/static/'
 STATIC_ROOT = BASE_DIR / 'staticfiles'
+# Use WhiteNoise to serve static files efficiently
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 # STATICFILES_DIRS = [BASE_DIR / 'static'] # For development static files outside apps
 
 # Media files (User-uploaded content like product images)

--- a/backend/backend/wsgi.py
+++ b/backend/backend/wsgi.py
@@ -10,7 +10,9 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from whitenoise import WhiteNoise
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 
 application = get_wsgi_application()
+application = WhiteNoise(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Project requirements
 # This references the backend dependencies
 -r backend/requirements.txt
+whitenoise>=6.0,<7.0


### PR DESCRIPTION
## Summary
- add whitenoise to root requirements
- configure WhiteNoise middleware and settings
- wrap WSGI application with WhiteNoise

## Testing
- `python backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685309fb9c34832088fdac568676b804