### PR TITLE
Fix Next.js configuration syntax

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -10,7 +10,7 @@ const nextConfig = {
         protocol: 'http',
         hostname: 'localhost',
         port: '8000',
-        pathname: '//uploads/**
+        pathname: '/uploads/**',
       },
       {
         protocol: 'https',
@@ -24,7 +24,7 @@ if (process.env.NEXT_PUBLIC_BACKEND_HOST) {
   nextConfig.images.remotePatterns.push({
     protocol: 'https',
     hostname: process.env.NEXT_PUBLIC_BACKEND_HOST,
-    pathname: '/medi/uploads/**
+    pathname: '/media/uploads/**',
   });
 }
 


### PR DESCRIPTION
## Summary
- fix path strings in `next.config.js` so Next.js can load config during build

## Testing
- `npm run build` *(fails: `next` not found because packages are missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853196917d4832099d2ace42dcd975c