### PR TITLE
Use shared API_ROOT constant

### DIFF
--- a/frontend/src/components/Common/APITestComponent.tsx
+++ b/frontend/src/components/Common/APITestComponent.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useState } from 'react';
 // Adjust these import paths if your files are located elsewhere!
-import { getCategories, getProducts, PaginatedProducts } from '@/lib/apiService';
+import { getCategories, getProducts, API_ROOT, PaginatedProducts } from '@/lib/apiService';
 import { Category } from '@/types/category';
 import { Product, PaginatedProducts } from '@/types/product';
 
@@ -16,12 +16,12 @@ const APITestComponent = () => {
   const [isLoadingProducts, setIsLoadingProducts] = useState(true);
 
   useEffect(() => {
-    console.log("API_BASE_URL from env:", process.env.NEXT_PUBLIC_API_BASE_URL);
+    console.log("API_BASE_URL from env:", API_ROOT);
 
     const getCategories = async () => {
       setIsLoadingCategories(true);
       setCategoryError(null);
-      const categoriesUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000/api'}/shop/categories/?limit=100`;
+      const categoriesUrl = `${API_ROOT}/shop/categories/?limit=100`;
       console.log("Attempting to fetch categories from URL:", categoriesUrl);
       try {
         const response = await fetch(categoriesUrl);
@@ -58,7 +58,7 @@ const APITestComponent = () => {
     const getProducts = async () => {
       setIsLoadingProducts(true);
       setProductError(null);
-      const productsUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000/api'}/shop/products/`;
+      const productsUrl = `${API_ROOT}/shop/products/`;
       console.log("Attempting to fetch products from URL:", productsUrl);
       try {
         const response = await fetch(productsUrl);
@@ -99,7 +99,7 @@ const APITestComponent = () => {
   return (
     <div style={{ padding: '20px', border: '1px solid #ccc', margin: '20px', backgroundColor: '#f9f9f9' }}>
       <h2>API Connection Test Component</h2>
-      <p><strong>API Base URL (from env):</strong> {process.env.NEXT_PUBLIC_API_BASE_URL || 'Not Set - Using default http://127.0.0.1:8000/api'}</p>
+      <p><strong>API Base URL:</strong> {API_ROOT}</p>
 
       <div style={{ marginTop: '15px', padding: '10px', border: '1px dashed #aaa' }}>
         <h3>Categories Status:</h3>

--- a/frontend/src/components/Home/Categories/index.tsx
+++ b/frontend/src/components/Home/Categories/index.tsx
@@ -6,7 +6,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css/navigation";
 import "swiper/css";
 
-import { getCategories } from '@/lib/apiService'; // Corrected import
+import { getCategories, API_ROOT } from '@/lib/apiService';
 import { Category as CategoryType } from '@/types/product'; // Using richer Category type from product.ts
 import SingleItem from "./SingleItem";
 import Image from "next/image"; // For navigation button icons
@@ -62,7 +62,7 @@ const Categories = () => {
           <div className="mb-10 text-center">
             <h2 className="font-semibold text-xl text-red-500">Error Loading Categories</h2>
             <p className="text-red-400">{error}</p>
-            <p className="text-xs text-gray-500 mt-1">Tried to fetch from: {process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000/api'}/shop/categories/</p>
+            <p className="text-xs text-gray-500 mt-1">Tried to fetch from: {API_ROOT}/shop/categories/</p>
             <p className="text-xs text-gray-500 mt-1">Please ensure the backend server is running and accessible.</p>
           </div>
         </div>

--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -7,7 +7,9 @@ import { User, AuthTokens, LoginCredentials, RegisterData, Address, ChangePasswo
 import { SlideshowItem } from "@/types/slideshow";
 import { PromoBanner } from "@/types/promoBanner";
 
-const API_ROOT = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000/api";
+// Exported so other modules can use the same base URL logic
+export const API_ROOT = process.env.NEXT_PUBLIC_API_BASE_URL ||
+  "http://localhost:8000/api";
 
 export interface PaginatedResponse<T> {
   count: number;


### PR DESCRIPTION
## Summary
- export `API_ROOT` from `apiService`
- reference `API_ROOT` in Categories and API test component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `python backend/manage.py test` *(fails: Django missing)*

------
https://chatgpt.com/codex/tasks/task_e_68531eb76f9883209aeee97f3dbbb3bd