### PR TITLE
Fix API base URL

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,4 +1,4 @@
 # Example frontend environment configuration
-NEXT_PUBLIC_API_BASE_URL=https://marked-egret-parmjot23-3f15c39c.koyeb.app/api
+NEXT_PUBLIC_API_BASE_URL=https://marked-egret-parmjot23-31f5c39c.koyeb.app/api
 # Uncomment and set this in production if you host the backend elsewhere
-NEXT_PUBLIC_BACKEND_HOST=marked-egret-parmjot23-3f15c39c.koyeb.app
+NEXT_PUBLIC_BACKEND_HOST=marked-egret-parmjot23-31f5c39c.koyeb.app

--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -9,7 +9,7 @@ import { PromoBanner } from "@/types/promoBanner";
 
 // Exported so other modules can use the same base URL logic
 export const API_ROOT = process.env.NEXT_PUBLIC_API_BASE_URL ||
-  "http://localhost:8000/api";
+  "https://marked-egret-parmjot23-31f5c39c.koyeb.app/api";
 
 export interface PaginatedResponse<T> {
   count: number;


### PR DESCRIPTION
## Summary
- set API base URL to the deployed backend
- update example environment file

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685324665f1083209175dfec54c6fbcb