### PR TITLE
Disable Next.js image optimization

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,6 +5,8 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
+    // Disable Next.js image optimization so external URLs are served directly
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'http',


### PR DESCRIPTION
## Summary
- configure `next.config.js` to disable Next.js image optimization so remote media URLs are used directly

## Testing
- `npm run lint` *(fails: next not found - dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685355ea28648320b7cd169471c9ebb4