### PR TITLE
Fix product fetch slug encoding

### DIFF
--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -152,7 +152,8 @@ export const getProducts = (params?: GetProductsParams): Promise<PaginatedProduc
 };
 
 export const getProductBySlug = (slug: string): Promise<Product> => {
-  return fetchWrapper<Product>(`${SHOP_BASE_URL}/products/${slug}/`);
+  const encoded = encodeURIComponent(slug);
+  return fetchWrapper<Product>(`${SHOP_BASE_URL}/products/${encoded}/`);
 };
 
 export interface GetCategoriesParams {


### PR DESCRIPTION
## Summary
- encode product slug in `getProductBySlug`

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68535fcd70d883208a8e91f793c8bb36