### PR TITLE
Fix slug encoding on shop links

### DIFF
--- a/frontend/src/components/Common/ProductItem.tsx
+++ b/frontend/src/components/Common/ProductItem.tsx
@@ -140,7 +140,10 @@ const ProductItem = ({ item }: { item: Product }) => {
   return (
     <div className="group flex flex-col h-full rounded-lg bg-white shadow-md hover:shadow-lg transition-shadow duration-300 ease-in-out overflow-hidden">
       <div className="relative overflow-hidden flex items-center justify-center bg-gray-100 aspect-square w-full">
-        <Link href={`/shop-details/${item.slug}`} className="block w-full h-full">
+        <Link
+          href={`/shop-details/${encodeURIComponent(item.slug)}`}
+          className="block w-full h-full"
+        >
           <Image
             src={imageUrl}
             alt={item.name || "Product image"}
@@ -208,7 +211,10 @@ const ProductItem = ({ item }: { item: Product }) => {
           <p className="text-xs text-gray-600">({reviewCount})</p>
         </div>
         <h3 className="font-semibold text-sm text-dark hover:text-blue transition-colors duration-200 mb-1.5 flex-grow">
-          <Link href={`/shop-details/${item.slug}`} className="line-clamp-2">
+          <Link
+            href={`/shop-details/${encodeURIComponent(item.slug)}`}
+            className="line-clamp-2"
+          >
             {item.name}
           </Link>
         </h3>

--- a/frontend/src/components/Common/QuickViewModal.tsx
+++ b/frontend/src/components/Common/QuickViewModal.tsx
@@ -371,7 +371,7 @@ const QuickViewModal = () => {
 
             <div className="mt-5">
               <Link
-                href={`/shop-details/${product.slug}`}
+                href={`/shop-details/${encodeURIComponent(product.slug)}`}
                 onClick={handleModalClose}
                 className="text-sm font-medium text-primary hover:underline"
               >

--- a/frontend/src/components/Home/BestSeller/SingleItem.tsx
+++ b/frontend/src/components/Home/BestSeller/SingleItem.tsx
@@ -132,7 +132,11 @@ const SingleItem = ({ item }: { item: Product }) => {
   return (
     <div className="group flex flex-col h-full rounded-lg bg-white shadow-md hover:shadow-lg transition-shadow duration-300 ease-in-out overflow-hidden">
       <div className="relative overflow-hidden flex items-center justify-center bg-gray-100 aspect-square w-full">
-        <Link href={`/shop-details/${item.slug}`} onClick={handleProductDetailsLink} className="block w-full h-full">
+        <Link
+          href={`/shop-details/${encodeURIComponent(item.slug)}`}
+          onClick={handleProductDetailsLink}
+          className="block w-full h-full"
+        >
           <Image
             src={imageUrl}
             alt={item.name || "Best seller product image"}
@@ -200,7 +204,11 @@ const SingleItem = ({ item }: { item: Product }) => {
         <h3
           className="font-semibold text-sm text-dark hover:text-blue transition-colors duration-200 mb-1.5 flex-grow"
         >
-          <Link href={`/shop-details/${item.slug}`} onClick={handleProductDetailsLink} className="line-clamp-2">
+          <Link
+            href={`/shop-details/${encodeURIComponent(item.slug)}`}
+            onClick={handleProductDetailsLink}
+            className="line-clamp-2"
+          >
             {item.name}
           </Link>
         </h3>

--- a/frontend/src/components/Orders/OrderDetails.tsx
+++ b/frontend/src/components/Orders/OrderDetails.tsx
@@ -75,7 +75,10 @@ const OrderDetails = ({ orderItem: order }: OrderDetailsProps) => {
                 />
               </div>
               <div className="flex-grow min-w-0">
-                <Link href={`/shop-details/${item.product_details?.slug || item.product_id}`} className="text-sm font-medium text-dark dark:text-white hover:text-blue dark:hover:text-blue transition-colors truncate block">
+                <Link
+                  href={`/shop-details/${encodeURIComponent(item.product_details?.slug || String(item.product_id))}`}
+                  className="text-sm font-medium text-dark dark:text-white hover:text-blue dark:hover:text-blue transition-colors truncate block"
+                >
                   {item.product_details?.name || `Product ID: ${item.product_id}`}
                 </Link>
                 <p className="text-xs text-gray-500 dark:text-gray-400">Qty: {item.quantity}</p>

--- a/frontend/src/components/Shop/SingleGridItem.tsx
+++ b/frontend/src/components/Shop/SingleGridItem.tsx
@@ -131,7 +131,10 @@ const SingleGridItem = ({ product: item, gridSize = 3 }: { product: Product; gri
   return (
     <div className="group flex flex-col h-full rounded-lg bg-white shadow-md hover:shadow-lg transition-shadow duration-300 ease-in-out overflow-hidden">
       <div className="relative overflow-hidden flex items-center justify-center bg-gray-100 aspect-square w-full">
-        <Link href={`/shop-details/${item.slug}`} className="block w-full h-full">
+        <Link
+          href={`/shop-details/${encodeURIComponent(item.slug)}`}
+          className="block w-full h-full"
+        >
           <Image
             src={imageUrl}
             alt={item.name || "Product image"}
@@ -199,7 +202,10 @@ const SingleGridItem = ({ product: item, gridSize = 3 }: { product: Product; gri
           )}
         </div>
         <h3 className="font-semibold text-sm text-dark hover:text-blue transition-colors duration-200 mb-1.5 flex-grow">
-          <Link href={`/shop-details/${item.slug}`} className="line-clamp-2">
+          <Link
+            href={`/shop-details/${encodeURIComponent(item.slug)}`}
+            className="line-clamp-2"
+          >
             {item.name}
           </Link>
         </h3>

--- a/frontend/src/components/Shop/SingleListItem.tsx
+++ b/frontend/src/components/Shop/SingleListItem.tsx
@@ -138,7 +138,10 @@ const SingleListItem = ({ item }: { item: Product }) => {
     <div className="group rounded-lg bg-white shadow-md hover:shadow-lg transition-shadow duration-300 ease-in-out">
       <div className="flex flex-col sm:flex-row">
         <div className="relative overflow-hidden flex items-center justify-center sm:max-w-[270px] w-full aspect-square sm:aspect-auto bg-gray-100 p-4 rounded-t-lg sm:rounded-l-lg sm:rounded-tr-none">
-          <Link href={`/shop-details/${item.slug}`} className="block w-full h-full">
+        <Link
+          href={`/shop-details/${encodeURIComponent(item.slug)}`}
+          className="block w-full h-full"
+        >
             <Image
               src={imageUrl}
               alt={item.name || "Product image"}
@@ -171,7 +174,10 @@ const SingleListItem = ({ item }: { item: Product }) => {
               <p className="text-xs text-gray-600">({reviewCount} Reviews)</p>
             </div>
             <h3 className="font-semibold text-base text-dark hover:text-blue transition-colors duration-200 mb-2">
-              <Link href={`/shop-details/${item.slug}`} className="line-clamp-2">
+              <Link
+                href={`/shop-details/${encodeURIComponent(item.slug)}`}
+                className="line-clamp-2"
+              >
                 {item.name}
               </Link>
             </h3>

--- a/frontend/src/components/Wishlist/SingleItem.tsx
+++ b/frontend/src/components/Wishlist/SingleItem.tsx
@@ -113,7 +113,9 @@ const SingleItem = ({ item, onRemoveSuccess }: { item: Product; onRemoveSuccess:
           </div>
           <div className="min-w-0">
             <h3 className="text-dark dark:text-white ease-out duration-200 hover:text-blue dark:hover:text-blue text-sm sm:text-base font-medium truncate">
-              <Link href={`/shop-details/${item.slug || item.id}`}> {item.name} </Link>
+              <Link
+                href={`/shop-details/${encodeURIComponent(item.slug || String(item.id))}`}
+              > {item.name} </Link>
             </h3>
             {/* Display original price if there's a discount */}
             {isAuthenticated && currentDiscountedPrice !== null && currentDiscountedPrice < currentPrice && (

--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -152,7 +152,8 @@ export const getProducts = (params?: GetProductsParams): Promise<PaginatedProduc
 };
 
 export const getProductBySlug = (slug: string): Promise<Product> => {
-  return fetchWrapper<Product>(`${SHOP_BASE_URL}/products/${slug}/`);
+  const encoded = encodeURIComponent(slug);
+  return fetchWrapper<Product>(`${SHOP_BASE_URL}/products/${encoded}/`);
 };
 
 export interface GetCategoriesParams {


### PR DESCRIPTION
## Summary
- encode product slug in all shop detail links to avoid malformed URLs

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_68535fcd70d883208a8e91f793c8bb36