### PR TITLE
Fix slug lookup to allow dots

### DIFF
--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -98,6 +98,7 @@ class ProductViewSet(viewsets.ModelViewSet):
     serializer_class = ProductSerializer
     permission_classes = [permissions.AllowAny] # Or IsAdminOrReadOnly for modifications
     lookup_field = 'slug'
+    lookup_value_regex = r'[^/]+'
 
     # Filtering, Searching, Ordering
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]


### PR DESCRIPTION
## Summary
- allow special characters like `.` in product slug lookups

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68537db714248320a09f3c9835592405