### PR TITLE
Fix product slug pattern

### DIFF
--- a/backend/shop/tests.py
+++ b/backend/shop/tests.py
@@ -1,3 +1,29 @@
-from django.test import TestCase
+from decimal import Decimal
+from urllib.parse import quote
 
-# Create your tests here.
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from shop.models import Brand, Category, Product
+
+
+class ProductSlugPatternTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.brand = Brand.objects.create(name="BrandZ")
+        self.category = Category.objects.create(name="Gadgets")
+        self.special_slug = "case.v2_test+(2024),edition"
+        self.product = Product.objects.create(
+            name="Special Gadget",
+            slug=self.special_slug,
+            category=self.category,
+            brand=self.brand,
+            price=Decimal("49.99"),
+        )
+
+    def test_retrieve_product_with_special_slug(self):
+        url = f"/api/shop/products/{quote(self.special_slug, safe='')}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["slug"], self.special_slug)
+

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -98,6 +98,8 @@ class ProductViewSet(viewsets.ModelViewSet):
     serializer_class = ProductSerializer
     permission_classes = [permissions.AllowAny] # Or IsAdminOrReadOnly for modifications
     lookup_field = 'slug'
+    # Allow dots, underscores, commas, plus signs and parentheses in slugs
+    lookup_value_regex = r'[-\w.,+()]+'
     
 
     # Filtering, Searching, Ordering


### PR DESCRIPTION
## Summary
- broaden the product slug pattern to allow more special characters
- test retrieving a product with a slug containing special characters

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r ../requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<5.0,>=4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68538681698483209a7a81bcac3bfe0d