### PR TITLE
Fix product details page rendering

### DIFF
--- a/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
+++ b/frontend/src/app/(site)/(pages)/shop-details/[slug]/page.tsx
@@ -1,83 +1,74 @@
-// src/app/(site)/(pages)/shop-details/[slug]/page.tsx
-import React from 'react';
-import ShopDetailsComponent from '@/components/ShopDetails'; // Assuming your main component is named ShopDetails
-import { getProductBySlug } from '@/lib/apiService';
-import { Product } from '@/types/product';
-import type { Metadata, ResolvingMetadata } from 'next';
-import type { PageProps } from '@/types/PageProps';
-import APITestComponent from '@/components/Common/APITestComponent'; // For easy debugging
+"use client";
 
-type ProductDetailsPageProps = PageProps<{
-  slug: string;
-}>;
+import { useEffect, useState } from "react";
+import ShopDetailsComponent from "@/components/ShopDetails";
+import { getProductBySlug } from "@/lib/apiService";
+import type { Product } from "@/types/product";
+import type { PageProps } from "@/types/PageProps";
 
-// Function to generate metadata dynamically
-export async function generateMetadata(
-  { params }: ProductDetailsPageProps,
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  const slug = params.slug;
-  try {
-    const product = await getProductBySlug(slug);
-    if (!product) {
-      return {
-        title: 'Product Not Found',
-        description: 'The product you are looking for does not exist.',
-      };
-    }
-    return {
-      title: `${product.name || 'Product Details'} | Celtrix Wireless Ltd`,
-      description: product.description?.substring(0, 160) || `Details for ${product.name}`,
-      openGraph: {
-        title: product.name || 'Product Details',
-        description: product.description?.substring(0, 160) || 'Check out this product.',
-        images: product.cover_image_url ? [product.cover_image_url] : ((product.imgs?.previews && product.imgs.previews.length > 0) ? [product.imgs.previews[0]] : []),
-      },
-    };
-  } catch (error) {
-    console.error(`Error fetching metadata for product slug ${slug}:`, error);
-    return {
-      title: 'Error Fetching Product',
-      description: 'Could not load product details at this time.',
-    };
-  }
+function fallbackSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[\u2013\u2014]/g, "-")
+    .replace(/[()]/g, "")
+    .replace(/[^a-z0-9-_]+/g, "-")
+    .replace(/-+/g, "-");
 }
 
+export default function ProductDetailsPage({ params }: PageProps<{ slug: string }>) {
+  const { slug } = params;
+  const [product, setProduct] = useState<Product | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
-// This is a React Server Component (RSC) by default in Next.js App Router
-export default async function ProductDetailsPage({ params }: ProductDetailsPageProps) {
-  const slug = params.slug;
-  let product: Product | null = null;
-  let error: string | null = null;
+  useEffect(() => {
+    async function fetchProduct(current: string, triedFallback = false) {
+      try {
+        const p = await getProductBySlug(current);
+        setProduct(p);
+        setError(null);
+      } catch (err: any) {
+        if (!triedFallback && err.status === 404) {
+          const alt = fallbackSlug(current);
+          if (alt !== current) {
+            return fetchProduct(alt, true);
+          }
+        }
+        console.error(`Failed to fetch product with slug "${current}":`, err);
+        setError(err.data?.detail || err.message || "Failed to load product details.");
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchProduct(slug);
+  }, [slug]);
 
-  try {
-    product = await getProductBySlug(slug);
-  } catch (err: any) {
-    console.error(`Failed to fetch product with slug "${slug}":`, err);
-    error = err.data?.detail || err.message || "Failed to load product details. Please try again later.";
+  if (loading) {
+    return (
+      <div style={{ padding: "50px", textAlign: "center", fontSize: "20px" }}>
+        Loading product...
+      </div>
+    );
   }
 
   if (error) {
     return (
-      <div style={{ padding: '50px', textAlign: 'center', fontSize: '20px', color: 'red' }}>
+      <div style={{ padding: "50px", textAlign: "center", fontSize: "20px", color: "red" }}>
         <h1>Error Loading Product</h1>
         <p>{error}</p>
-        {/* You might want to add a link back to the shop or homepage here */}
-        {/* <APITestComponent /> */} {/* For debugging API connectivity from server-side */}
       </div>
     );
   }
 
   if (!product) {
     return (
-      <div style={{ padding: '50px', textAlign: 'center', fontSize: '20px' }}>
+      <div style={{ padding: "50px", textAlign: "center", fontSize: "20px" }}>
         <h1>Product Not Found</h1>
-        <p>The product you are looking for (slug: <strong>{slug}</strong>) does not exist or could not be loaded.</p>
-        {/* <APITestComponent /> */} {/* For debugging API connectivity from server-side */}
+        <p>The product you are looking for does not exist.</p>
       </div>
     );
   }
 
-  // If product is found, pass it to the client component
   return <ShopDetailsComponent product={product} />;
 }


### PR DESCRIPTION
## Summary
- switch product details page to a client component
- add fallback slug logic and better loading/errors

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68541c9f5340832086d8145761dfd956