### PR TITLE
Improve mobile responsiveness for hero and promo banners

### DIFF
--- a/frontend/src/components/Home/Hero/HeroCarousel.tsx
+++ b/frontend/src/components/Home/Hero/HeroCarousel.tsx
@@ -55,11 +55,11 @@ const HeroCarousal = () => {
     >
       {heroProducts.map((item, idx) => (
         <SwiperSlide key={idx}>
-          <div className="relative h-[70vh] flex items-center justify-center gap-8 sm:gap-12 overflow-hidden px-4 sm:px-8 xl:px-0 max-w-[1170px] mx-auto">
+          <div className="relative h-[70vh] flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-12 overflow-hidden px-4 sm:px-8 xl:px-0 max-w-[1170px] mx-auto">
             <div className={`absolute inset-0 bg-gradient-to-r ${gradientClasses[idx % gradientClasses.length]}`}></div>
             <div className="absolute inset-0 bg-white/60"></div>
 
-            <div className="relative z-10 flex flex-col items-center sm:items-start text-center sm:text-left max-w-md">
+            <div className="relative z-10 flex flex-col items-center sm:items-start text-center sm:text-left max-w-md bg-white/80 p-4 sm:p-0 sm:bg-transparent rounded">
               <DiscountBadge percentage={item.discount} className="mb-4" />
               <h2 className="font-bold text-3xl sm:text-4xl md:text-5xl text-dark-base mb-3">
                 {item.title}
@@ -73,8 +73,8 @@ const HeroCarousal = () => {
               </Link>
             </div>
 
-            <div className="relative z-10 hidden sm:block">
-              <Image src={item.image} alt={item.title} width={380} height={380} />
+            <div className="relative z-10">
+              <Image src={item.image} alt={item.title} width={380} height={380} className="w-60 sm:w-auto h-auto" />
             </div>
           </div>
         </SwiperSlide>

--- a/frontend/src/components/Home/PromoBanner/index.tsx
+++ b/frontend/src/components/Home/PromoBanner/index.tsx
@@ -28,7 +28,7 @@ const PromoBanner = () => {
       <div className="max-w-[1170px] w-full mx-auto px-4 sm:px-8 xl:px-0">
         {big && (
           <div className="relative z-1 overflow-hidden rounded-lg bg-[#F5F5F7] py-12.5 lg:py-17.5 xl:py-22.5 px-4 sm:px-7.5 lg:px-14 xl:px-19 mb-7.5">
-            <div className="max-w-[550px] w-full">
+            <div className="max-w-[550px] w-full bg-white/80 p-4 sm:p-0 sm:bg-transparent rounded">
               <span className="block font-medium text-xl text-dark mb-3">
                 {big.product_details?.name}
               </span>
@@ -49,7 +49,7 @@ const PromoBanner = () => {
               <Image
                 src={getImage(big.product_details) as string}
                 alt={big.product_details?.name || "Promo image"}
-                className="absolute bottom-0 right-4 lg:right-26 -z-1"
+                className="absolute bottom-0 right-4 lg:right-26 -z-1 w-40 sm:w-[274px] h-auto"
                 width={274}
                 height={350}
               />
@@ -67,13 +67,13 @@ const PromoBanner = () => {
                 <Image
                   src={getImage(banner.product_details) as string}
                   alt={banner.product_details?.name || "Promo image"}
-                  className={`absolute top-1/2 -translate-y-1/2 ${idx === 0 ? 'left-3 sm:left-10' : 'right-3 sm:right-8.5'} -z-1`}
+                  className={`absolute top-1/2 -translate-y-1/2 ${idx === 0 ? 'left-3 sm:left-10 w-32 sm:w-[241px]' : 'right-3 sm:right-8.5 w-28 sm:w-[200px]'} -z-1 h-auto`}
                   width={idx === 0 ? 241 : 200}
                   height={idx === 0 ? 241 : 200}
                 />
               )}
 
-              <div className={idx === 0 ? 'text-right' : ''}>
+              <div className={`${idx === 0 ? 'text-right' : ''} relative z-10 bg-white/80 p-3 sm:p-0 sm:bg-transparent rounded`}>
                 <span className="block text-lg text-dark mb-1.5">
                   {banner.product_details?.name}
                 </span>


### PR DESCRIPTION
## Summary
- make HeroCarousel show images on small screens
- add background overlay for hero text
- tweak promo banner layouts and sizes for mobiles

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68547d8ebd348320b08b5431e1e99a8c