### PR TITLE
Fix horizontal scroll issue on shop pages

### DIFF
--- a/frontend/src/app/css/style.css
+++ b/frontend/src/app/css/style.css
@@ -4,7 +4,7 @@
 
 @layer base {
   html {
-    @apply scroll-smooth;
+    @apply scroll-smooth overflow-x-hidden;
   }
 
   body {


### PR DESCRIPTION
## Summary
- prevent horizontal overflow from body on all pages by applying `overflow-x-hidden` to the html element

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854886473f08320a7dbf39e60150f90