### PR TITLE
Add Wishlist link to navigation

### DIFF
--- a/frontend/src/components/Header/menuData.ts
+++ b/frontend/src/components/Header/menuData.ts
@@ -19,5 +19,11 @@ export const menuData: Menu[] = [
     newTab: false,
     path: "/contact",
   },
+  {
+    id: 4,
+    title: "Wishlist",
+    newTab: false,
+    path: "/wishlist",
+  },
   // The "pages" and "blogs" sections have been removed from navigation
 ];


### PR DESCRIPTION
## Summary
- add wishlist link to Header menu data so users can navigate to their saved items

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68549159b1ec8320914661392e09062f