### PR TITLE
Fix order endpoint path

### DIFF
--- a/backend/orders/views.py
+++ b/backend/orders/views.py
@@ -22,7 +22,8 @@ class OrderViewSet(viewsets.ModelViewSet):
         else:
             serializer.save() # For guest checkouts, user will be null
 
-    @action(detail=False, methods=['post'], serializer_class=OrderCreateFromCartSerializer)
+    # Use a hyphen in the URL to match the frontend expectation
+    @action(detail=False, methods=['post'], serializer_class=OrderCreateFromCartSerializer, url_path='from-cart')
     def from_cart(self, request):
         """Create an order using the authenticated user's cart items."""
         user = request.user


### PR DESCRIPTION
## Summary
- update from_cart action to use `from-cart` URL path

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854b76213e48320bd54274f2dde82c3