### PR TITLE
Add global cart context

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('api/orders/', include('orders.urls')),
     path('api/wishlists/', include('wishlists.urls')),
     path('api/carts/', include('carts.urls')),
+    path('api/cart/', include('carts.urls')),
     path('api/testimonials/', include('testimonials.urls')),
     path('accounts/', include('django.contrib.auth.urls')),
     # You would add other app API urls here, e.g.:

--- a/backend/carts/tests.py
+++ b/backend/carts/tests.py
@@ -34,7 +34,7 @@ class CartPersistenceTests(APITestCase):
         self.authenticate()
 
         add_resp = self.client.post(
-            "/api/carts/add-item/",
+            "/api/cart/add/",
             {"product_id": self.product.id, "quantity": 2},
             format="json",
         )

--- a/backend/carts/views.py
+++ b/backend/carts/views.py
@@ -18,7 +18,7 @@ class CartViewSet(viewsets.GenericViewSet):
         serializer = self.get_serializer(cart)
         return Response(serializer.data)
 
-    @action(detail=False, methods=['post'], serializer_class=AddToCartSerializer, url_path='add-item')
+    @action(detail=False, methods=['post'], serializer_class=AddToCartSerializer, url_path='add')
     def add_item(self, request):
         cart, _ = Cart.objects.get_or_create(user=request.user)
         serializer = AddToCartSerializer(data=request.data)
@@ -40,7 +40,7 @@ class CartViewSet(viewsets.GenericViewSet):
             return Response(item_serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    @action(detail=False, methods=['put'], serializer_class=AddToCartSerializer, url_path='update-item/(?P<product_pk>[^/.]+)')
+    @action(detail=False, methods=['put'], serializer_class=AddToCartSerializer, url_path='update/(?P<product_pk>[^/.]+)')
     def update_item(self, request, product_pk=None):
         cart = Cart.objects.filter(user=request.user).first()
         if not cart:
@@ -57,7 +57,7 @@ class CartViewSet(viewsets.GenericViewSet):
         serializer = CartItemSerializer(item, context={'request': request})
         return Response(serializer.data)
 
-    @action(detail=False, methods=['delete'], url_path='remove-item/(?P<product_pk>[^/.]+)')
+    @action(detail=False, methods=['delete'], url_path='remove/(?P<product_pk>[^/.]+)')
     def remove_item(self, request, product_pk=None):
         cart = Cart.objects.filter(user=request.user).first()
         if not cart:

--- a/backend/orders/tests.py
+++ b/backend/orders/tests.py
@@ -61,7 +61,7 @@ class OrderModelTests(APITestCase):
         self.authenticate()
 
         add_resp = self.client.post(
-            "/api/carts/add-item/",
+            "/api/cart/add/",
             {"product_id": self.product.id, "quantity": 2},
             format="json",
         )

--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -21,7 +21,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 import { store } from "@/redux/store"; // Import the store
 import { loadUserFromStorage } from "@/redux/features/auth-slice"; // Import the action
-import CartInitializer from "@/components/Common/CartInitializer";
+import { CartProvider } from "@/app/context/CartContext";
 
 export default function RootLayout({
   children,
@@ -43,11 +43,11 @@ export default function RootLayout({
           <PreLoader />
         ) : (
           <>
-            <ReduxProvider> {/* ReduxProvider wraps everything */}
-              <CartInitializer />
-              <CartModalProvider>
-                <QuickViewModalProvider>
-                  <PreviewSliderProvider>
+            <ReduxProvider>
+              <CartProvider>
+                <CartModalProvider>
+                  <QuickViewModalProvider>
+                    <PreviewSliderProvider>
                     <HeaderWithSuspense />
                     <main className="pt-28 md:pt-32 xl:pt-40">
                       {children}
@@ -55,9 +55,10 @@ export default function RootLayout({
                     <QuickViewModal />
                     <CartSidebarModal />
                     <PreviewSliderModal />
-                  </PreviewSliderProvider>
-                </QuickViewModalProvider>
-              </CartModalProvider>
+                    </PreviewSliderProvider>
+                  </QuickViewModalProvider>
+                </CartModalProvider>
+              </CartProvider>
             </ReduxProvider>
             <ScrollToTop />
             <Footer />

--- a/frontend/src/app/context/CartContext.tsx
+++ b/frontend/src/app/context/CartContext.tsx
@@ -1,0 +1,96 @@
+import React, { createContext, useContext, useEffect } from "react";
+import { useAppSelector, useAppDispatch } from "@/redux/store";
+import {
+  setCartItems,
+  CartItem,
+} from "@/redux/features/cart-slice";
+import {
+  getCart as apiGetCart,
+  addToCart as apiAddToCart,
+  updateCartItem as apiUpdateCartItem,
+  removeFromCart as apiRemoveFromCart,
+  clearCart as apiClearCart,
+} from "@/lib/apiService";
+
+interface CartContextType {
+  items: CartItem[];
+  cartCount: number;
+  totalPrice: number;
+  fetchCart: () => Promise<void>;
+  addItem: (productId: number, quantity: number) => Promise<void>;
+  updateItem: (productId: number, quantity: number) => Promise<void>;
+  removeItem: (productId: number) => Promise<void>;
+  clear: () => Promise<void>;
+}
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+export const useCart = () => {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error("useCart must be used within CartProvider");
+  return ctx;
+};
+
+export const CartProvider = ({ children }: { children: React.ReactNode }) => {
+  const dispatch = useAppDispatch();
+  const items = useAppSelector((state) => state.cartReducer.items);
+
+  const fetchCart = async () => {
+    try {
+      const apiItems = await apiGetCart();
+      const mapped = apiItems.map((item) => ({
+        id: item.product_details.id,
+        title: item.product_details.name,
+        price: Number(item.product_details.price),
+        discountedPrice: item.product_details.discounted_price
+          ? Number(item.product_details.discounted_price)
+          : Number(item.product_details.price),
+        quantity: item.quantity,
+        imgs: item.product_details.imgs,
+      }));
+      dispatch(setCartItems(mapped));
+    } catch (err) {
+      console.error("Failed to fetch cart", err);
+    }
+  };
+
+  const addItem = async (productId: number, quantity: number) => {
+    await apiAddToCart(productId, quantity);
+    await fetchCart();
+  };
+
+  const updateItem = async (productId: number, quantity: number) => {
+    await apiUpdateCartItem(productId, quantity);
+    await fetchCart();
+  };
+
+  const removeItem = async (productId: number) => {
+    await apiRemoveFromCart(productId);
+    await fetchCart();
+  };
+
+  const clear = async () => {
+    await apiClearCart();
+    await fetchCart();
+  };
+
+  useEffect(() => {
+    fetchCart();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const cartCount = items.reduce((sum, item) => sum + item.quantity, 0);
+  const totalPrice = items.reduce(
+    (total, item) => total + item.discountedPrice * item.quantity,
+    0
+  );
+
+  return (
+    <CartContext.Provider
+      value={{ items, cartCount, totalPrice, fetchCart, addItem, updateItem, removeItem, clear }}
+    >
+      {children}
+    </CartContext.Provider>
+  );
+};
+

--- a/frontend/src/components/Common/CartSidebarModal/SingleItem.tsx
+++ b/frontend/src/components/Common/CartSidebarModal/SingleItem.tsx
@@ -1,13 +1,9 @@
 import React from "react";
-import { useDispatch } from "react-redux";
-import { AppDispatch } from "@/redux/store";
 import Image from "next/image";
 
 const SingleItem = ({ item, removeItemFromCart }) => {
-  const dispatch = useDispatch<AppDispatch>();
-
   const handleRemoveFromCart = () => {
-    dispatch(removeItemFromCart(item.id));
+    removeItemFromCart(item.id);
   };
 
   return (

--- a/frontend/src/components/Common/CartSidebarModal/index.tsx
+++ b/frontend/src/components/Common/CartSidebarModal/index.tsx
@@ -2,21 +2,14 @@
 import React, { useEffect, useState } from "react";
 
 import { useCartModalContext } from "@/app/context/CartSidebarModalContext";
-import {
-  removeItemFromCart,
-  selectTotalPrice,
-} from "@/redux/features/cart-slice";
-import { useAppSelector } from "@/redux/store";
-import { useSelector } from "react-redux";
+import { useCart } from "@/app/context/CartContext";
 import SingleItem from "./SingleItem";
 import Link from "next/link";
 import EmptyCart from "./EmptyCart";
 
 const CartSidebarModal = () => {
   const { isCartModalOpen, closeCartModal } = useCartModalContext();
-  const cartItems = useAppSelector((state) => state.cartReducer.items);
-
-  const totalPrice = useSelector(selectTotalPrice);
+  const { items: cartItems, totalPrice, removeItem } = useCart();
 
   useEffect(() => {
     // closing modal while clicking outside
@@ -82,7 +75,7 @@ const CartSidebarModal = () => {
                   <SingleItem
                     key={key}
                     item={item}
-                    removeItemFromCart={removeItemFromCart}
+                    removeItemFromCart={removeItem}
                   />
                 ))
               ) : (

--- a/frontend/src/components/Common/QuickViewModal.tsx
+++ b/frontend/src/components/Common/QuickViewModal.tsx
@@ -5,11 +5,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { useQuickViewModalContext } from "@/app/context/QuickViewModalContext";
 import { Product } from "@/types/product";
+import { useCart } from "@/app/context/CartContext";
 import { useDispatch } from "react-redux";
 import { AppDispatch, useAppSelector } from "@/redux/store";
-import { addItemToCart } from "@/redux/features/cart-slice";
 import { addItemToWishlist } from "@/redux/features/wishlist-slice";
-import { addToCart as apiAddToCart } from "@/lib/apiService";
 import { toast } from "react-toastify";
 import PreviewSlider from "./PreviewSlider"; // Assuming this component is correctly implemented
 import { getProductBySlug } from "@/lib/apiService";
@@ -24,6 +23,7 @@ const QuickViewModal = () => {
 
   const dispatch = useDispatch<AppDispatch>();
   const isAuthenticated = useAppSelector((state) => state.authReducer.isAuthenticated);
+  const { addItem } = useCart();
 
   const [product, setProduct] = useState<Product | null>(null);
   const [loading, setLoading] = useState(false);
@@ -85,15 +85,7 @@ const QuickViewModal = () => {
       return;
     }
     try {
-      await apiAddToCart(product.id, quantity);
-      dispatch(
-        addItemToCart({
-          ...product,
-          quantity,
-          discountedPrice: effectivePrice,
-          price: Number(product.price),
-        })
-      );
+      await addItem(product.id, quantity);
       toast.success(`${product.name} added to cart`);
     } catch (err: any) {
       toast.error(err.data?.detail || err.message || "Failed to add to cart.");

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -5,8 +5,8 @@ import Link from "next/link";
 import CustomSelect from "./CustomSelect";
 import { menuData as headerMenuDataImport } from "./menuData";
 import Dropdown from "./Dropdown";
-import { useAppSelector, useAppDispatch } from "@/redux/store"; // Import useAppDispatch
-import { selectTotalPrice, removeAllItemsFromCart } from "@/redux/features/cart-slice";
+import { useAppDispatch } from "@/redux/store";
+import { useCart } from "@/app/context/CartContext";
 import { useCartModalContext } from "@/app/context/CartSidebarModalContext";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -43,8 +43,7 @@ const Header = () => {
   const [stickyMenu, setStickyMenu] = useState(false);
 
   // Cart state
-  const cartItems = useAppSelector((state) => state.cartReducer.items);
-  const totalPrice = useAppSelector(selectTotalPrice);
+  const { items: cartItems, totalPrice, clear } = useCart();
   const { openCartModal } = useCartModalContext();
 
   const headerMenuData: MenuType[] = Array.isArray(headerMenuDataImport)
@@ -143,7 +142,7 @@ const Header = () => {
 
   const handleLogout = () => {
     dispatch(logout());
-    dispatch(removeAllItemsFromCart());
+    clear();
     toast.info("You have been logged out.");
     router.push("/"); // Redirect to home or login page
     if (navigationOpen) setNavigationOpen(false);
@@ -176,7 +175,7 @@ const Header = () => {
             console.error("Failed to refresh token:", error);
             // If refresh fails (e.g., refresh token expired), log out user
             dispatch(logout());
-            dispatch(removeAllItemsFromCart());
+            clear();
             router.push('/signin'); // Redirect to sign-in
           }
         }

--- a/frontend/src/components/ShopDetails/index.tsx
+++ b/frontend/src/components/ShopDetails/index.tsx
@@ -11,9 +11,8 @@ import { Star, Heart, ShoppingCart } from "lucide-react";
 import DiscountBadge from "@/components/Common/DiscountBadge";
 import { useDispatch } from "react-redux";
 import { AppDispatch, useAppSelector } from "@/redux/store";
-import { addItemToCart } from "@/redux/features/cart-slice";
+import { useCart } from "@/app/context/CartContext";
 import { addItemToWishlist as addItemToWishlistAction } from "@/redux/features/wishlist-slice";
-import { addToCart as apiAddToCart } from "@/lib/apiService";
 import { updateproductDetails } from "@/redux/features/product-details"; // For PreviewSliderModal
 import { toast } from "react-toastify";
 import Link from "next/link"; // Import Link
@@ -120,6 +119,8 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
   const reviewCount = product.reviews || 0; // Using 'reviews' as per Product type
   const averageRating = product.average_rating ? Number(product.average_rating) : 0;
 
+  const { addItem } = useCart();
+
   const handleAddToCart = async () => {
     if (!product) return;
     if (!isAuthenticated) {
@@ -131,15 +132,7 @@ const ShopDetails = ({ product }: ShopDetailsProps) => {
       return;
     }
     try {
-      await apiAddToCart(product.id, quantity);
-      dispatch(
-        addItemToCart({
-          ...product,
-          quantity,
-          discountedPrice: effectivePrice,
-          price: Number(product.price),
-        })
-      );
+      await addItem(product.id, quantity);
       toast.success(`${product.name} (x${quantity}) added to cart`);
     } catch (err: any) {
       toast.error(err.data?.detail || err.message || "Failed to add to cart.");

--- a/frontend/src/lib/apiService.ts
+++ b/frontend/src/lib/apiService.ts
@@ -399,7 +399,7 @@ export const clearWishlist = (): Promise<void> => {
     });
 };
 
-const CART_BASE_URL = `${API_ROOT}/carts`;
+const CART_BASE_URL = `${API_ROOT}/cart`;
 
 export const getCart = (): Promise<ApiCartItem[]> => {
     return fetchWrapper<{id: number; user: number; items: ApiCartItem[]}>(`${CART_BASE_URL}/`)
@@ -407,21 +407,21 @@ export const getCart = (): Promise<ApiCartItem[]> => {
 };
 
 export const addToCart = (productId: number, quantity: number = 1): Promise<ApiCartItem> => {
-    return fetchWrapper<ApiCartItem>(`${CART_BASE_URL}/add-item/`, {
+    return fetchWrapper<ApiCartItem>(`${CART_BASE_URL}/add/`, {
         method: 'POST',
         body: JSON.stringify({ product_id: productId, quantity }),
     });
 };
 
 export const updateCartItem = (productId: number, quantity: number): Promise<ApiCartItem> => {
-    return fetchWrapper<ApiCartItem>(`${CART_BASE_URL}/update-item/${productId}/`, {
+    return fetchWrapper<ApiCartItem>(`${CART_BASE_URL}/update/${productId}/`, {
         method: 'PUT',
         body: JSON.stringify({ quantity }),
     });
 };
 
 export const removeFromCart = (productId: number): Promise<void> => {
-    return fetchWrapper<void>(`${CART_BASE_URL}/remove-item/${productId}/`, {
+    return fetchWrapper<void>(`${CART_BASE_URL}/remove/${productId}/`, {
         method: 'DELETE',
     });
 };


### PR DESCRIPTION
## Summary
- introduce CartProvider to centralize cart state
- use new `/api/cart/` routes in api service and backend
- wire Header and CartSidebar to the new context
- update QuickView modal and product detail page to add items through context
- include new cart paths in tests

## Testing
- `npm run lint` *(fails: `next` not found)*
- `python manage.py test` *(fails: `No module named 'django'`)*

------
https://chatgpt.com/codex/tasks/task_e_685578ef23f88320b46c01fdf62a9bcf