### PR TITLE
Fix footer links

### DIFF
--- a/frontend/src/app/(site)/(pages)/faqs/page.tsx
+++ b/frontend/src/app/(site)/(pages)/faqs/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "FAQs | NextCommerce",
+  description: "Frequently asked questions",
+};
+
+export default function FaqsPage() {
+  return (
+    <main className="py-24">
+      <div className="max-w-[1170px] mx-auto px-4">
+        <h1 className="text-2xl font-medium mb-4">FAQs</h1>
+        <p>Content coming soon.</p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/(site)/(pages)/privacy-policy/page.tsx
+++ b/frontend/src/app/(site)/(pages)/privacy-policy/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | NextCommerce",
+  description: "Privacy policy information",
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main className="py-24">
+      <div className="max-w-[1170px] mx-auto px-4">
+        <h1 className="text-2xl font-medium mb-4">Privacy Policy</h1>
+        <p>Content coming soon.</p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/(site)/(pages)/refund-policy/page.tsx
+++ b/frontend/src/app/(site)/(pages)/refund-policy/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Refund Policy | NextCommerce",
+  description: "Refund policy information",
+};
+
+export default function RefundPolicyPage() {
+  return (
+    <main className="py-24">
+      <div className="max-w-[1170px] mx-auto px-4">
+        <h1 className="text-2xl font-medium mb-4">Refund Policy</h1>
+        <p>Content coming soon.</p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/(site)/(pages)/terms-of-use/page.tsx
+++ b/frontend/src/app/(site)/(pages)/terms-of-use/page.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Use | NextCommerce",
+  description: "Terms of use information",
+};
+
+export default function TermsOfUsePage() {
+  return (
+    <main className="py-24">
+      <div className="max-w-[1170px] mx-auto px-4">
+        <h1 className="text-2xl font-medium mb-4">Terms of Use</h1>
+        <p>Content coming soon.</p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/Footer/index.tsx
+++ b/frontend/src/components/Footer/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Image from "next/image";
+import Link from "next/link";
 
 const Footer = () => {
   const year = new Date().getFullYear();
@@ -203,29 +204,29 @@ const Footer = () => {
 
             <ul className="flex flex-col gap-3.5">
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/my-account">
                   My Account
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/signin">
                   Login / Register
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/cart">
                   Cart
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/wishlist">
                   Wishlist
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/shop-with-sidebar">
                   Shop
-                </a>
+                </Link>
               </li>
             </ul>
           </div>
@@ -237,29 +238,29 @@ const Footer = () => {
 
             <ul className="flex flex-col gap-3">
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/privacy-policy">
                   Privacy Policy
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/refund-policy">
                   Refund Policy
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/terms-of-use">
                   Terms of Use
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/faqs">
                   FAQ’s
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/contact">
                   Contact
-                </a>
+                </Link>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- hook up `Link` components for account & quick links
- add placeholder pages for Privacy Policy, Refund Policy, Terms of Use and FAQs

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b9f2acd88320bb47154c60a3cf27