### PR TITLE
Add extended signup fields

### DIFF
--- a/backend/accounts/migrations/0003_user_additional_fields.py
+++ b/backend/accounts/migrations/0003_user_additional_fields.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0002_user_profile_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='company_name',
+            field=models.CharField(max_length=255, blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='phone_number',
+            field=models.CharField(max_length=20, blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='gst_hst_number',
+            field=models.CharField(max_length=50, blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='user',
+            name='pst_number',
+            field=models.CharField(max_length=50, blank=True, null=True),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -5,6 +5,10 @@ from django.utils.translation import gettext_lazy as _
 class User(AbstractUser):
     email = models.EmailField(_('email address'), unique=True)
     profile_image = models.ImageField(upload_to='profile_images/', blank=True, null=True)
+    company_name = models.CharField(max_length=255, blank=True, null=True)
+    phone_number = models.CharField(max_length=20, blank=True, null=True)
+    gst_hst_number = models.CharField(max_length=50, blank=True, null=True)
+    pst_number = models.CharField(max_length=50, blank=True, null=True)
 
     # Add or change related_name for groups and user_permissions
     # to avoid clashes with the default auth.User model.

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -10,7 +10,19 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('id', 'username', 'email', 'first_name', 'last_name', 'is_staff', 'profile_image')
+        fields = (
+            'id',
+            'username',
+            'email',
+            'first_name',
+            'last_name',
+            'company_name',
+            'phone_number',
+            'gst_hst_number',
+            'pst_number',
+            'is_staff',
+            'profile_image',
+        )
         read_only_fields = ('is_staff',)
 
 class RegisterSerializer(serializers.ModelSerializer):
@@ -19,10 +31,25 @@ class RegisterSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('username', 'email', 'password', 'password2', 'first_name', 'last_name')
+        fields = (
+            'username',
+            'email',
+            'password',
+            'password2',
+            'first_name',
+            'last_name',
+            'company_name',
+            'phone_number',
+            'gst_hst_number',
+            'pst_number',
+        )
         extra_kwargs = {
             'first_name': {'required': False},
             'last_name': {'required': False},
+            'company_name': {'required': False},
+            'phone_number': {'required': False},
+            'gst_hst_number': {'required': False},
+            'pst_number': {'required': False},
         }
 
     def validate(self, attrs):
@@ -36,7 +63,11 @@ class RegisterSerializer(serializers.ModelSerializer):
             email=validated_data['email'],
             password=validated_data['password'],
             first_name=validated_data.get('first_name', ''),
-            last_name=validated_data.get('last_name', '')
+            last_name=validated_data.get('last_name', ''),
+            company_name=validated_data.get('company_name', ''),
+            phone_number=validated_data.get('phone_number', ''),
+            gst_hst_number=validated_data.get('gst_hst_number', ''),
+            pst_number=validated_data.get('pst_number', ''),
         )
         return user
 

--- a/frontend/src/components/Auth/Signup/index.tsx
+++ b/frontend/src/components/Auth/Signup/index.tsx
@@ -14,6 +14,10 @@ const Signup = () => {
     password2: "",
     first_name: "",
     last_name: "",
+    company_name: "",
+    phone_number: "",
+    gst_hst_number: "",
+    pst_number: "",
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -44,6 +48,10 @@ const Signup = () => {
         password2: formData.password2,
         first_name: formData.first_name,
         last_name: formData.last_name,
+        company_name: formData.company_name,
+        phone_number: formData.phone_number,
+        gst_hst_number: formData.gst_hst_number,
+        pst_number: formData.pst_number,
       });
       toast.success("Registration successful! Please sign in.");
       router.push("/signin"); // Redirect to signin page
@@ -129,7 +137,7 @@ const Signup = () => {
                   className="rounded-lg border border-gray-3 bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20"
                 />
               </div>
-               <div className="mb-5">
+              <div className="mb-5">
                 <label htmlFor="last_name" className="block mb-2.5">
                   Last Name
                 </label>
@@ -142,6 +150,70 @@ const Signup = () => {
                   onChange={handleChange}
                   className="rounded-lg border border-gray-3 bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20"
                 />
+              </div>
+
+              <div className="mb-5">
+                <label htmlFor="company_name" className="block mb-2.5">
+                  Company Name
+                </label>
+                <input
+                  type="text"
+                  name="company_name"
+                  id="company_name"
+                  placeholder="Enter your company name"
+                  value={formData.company_name}
+                  onChange={handleChange}
+                  className="rounded-lg border border-gray-3 bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20"
+                />
+                {validationErrors.company_name && <p className="text-red-500 text-xs mt-1">{validationErrors.company_name.join(', ')}</p>}
+              </div>
+
+              <div className="mb-5">
+                <label htmlFor="phone_number" className="block mb-2.5">
+                  Phone Number
+                </label>
+                <input
+                  type="text"
+                  name="phone_number"
+                  id="phone_number"
+                  placeholder="Enter your phone number"
+                  value={formData.phone_number}
+                  onChange={handleChange}
+                  className="rounded-lg border border-gray-3 bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20"
+                />
+                {validationErrors.phone_number && <p className="text-red-500 text-xs mt-1">{validationErrors.phone_number.join(', ')}</p>}
+              </div>
+
+              <div className="mb-5">
+                <label htmlFor="gst_hst_number" className="block mb-2.5">
+                  GST/HST Number
+                </label>
+                <input
+                  type="text"
+                  name="gst_hst_number"
+                  id="gst_hst_number"
+                  placeholder="Enter your GST/HST number"
+                  value={formData.gst_hst_number}
+                  onChange={handleChange}
+                  className="rounded-lg border border-gray-3 bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20"
+                />
+                {validationErrors.gst_hst_number && <p className="text-red-500 text-xs mt-1">{validationErrors.gst_hst_number.join(', ')}</p>}
+              </div>
+
+              <div className="mb-5">
+                <label htmlFor="pst_number" className="block mb-2.5">
+                  PST Number
+                </label>
+                <input
+                  type="text"
+                  name="pst_number"
+                  id="pst_number"
+                  placeholder="Enter your PST number"
+                  value={formData.pst_number}
+                  onChange={handleChange}
+                  className="rounded-lg border border-gray-3 bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20"
+                />
+                {validationErrors.pst_number && <p className="text-red-500 text-xs mt-1">{validationErrors.pst_number.join(', ')}</p>}
               </div>
 
               <div className="mb-5">

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -6,6 +6,10 @@ export interface User {
   email: string;
   first_name?: string;
   last_name?: string;
+  company_name?: string;
+  phone_number?: string;
+  gst_hst_number?: string;
+  pst_number?: string;
   profile_image?: string;
   // Add any other fields your UserSerializer exposes
 }
@@ -31,6 +35,10 @@ export interface RegisterData {
   password2?: string; // Password confirmation
   first_name?: string;
   last_name?: string;
+  company_name?: string;
+  phone_number?: string;
+  gst_hst_number?: string;
+  pst_number?: string;
 }
 
 export interface Address {


### PR DESCRIPTION
## Summary
- extend `User` model with business info fields
- expose new fields via user serializers
- create migration for new fields
- update sign up form and types to send extra fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c20a308483209d938aedd3192046