### PR TITLE
Add user activation flag

### DIFF
--- a/backend/accounts/migrations/0004_alter_user_is_active.py
+++ b/backend/accounts/migrations/0004_alter_user_is_active.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0003_user_additional_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='is_active',
+            field=models.BooleanField(
+                default=False,
+                help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.',
+                verbose_name='active',
+            ),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -9,6 +9,13 @@ class User(AbstractUser):
     phone_number = models.CharField(max_length=20, blank=True, null=True)
     gst_hst_number = models.CharField(max_length=50, blank=True, null=True)
     pst_number = models.CharField(max_length=50, blank=True, null=True)
+    is_active = models.BooleanField(
+        _('active'),
+        default=False,
+        help_text=_(
+            'Designates whether this user should be treated as active. Unselect this instead of deleting accounts.'
+        ),
+    )
 
     # Add or change related_name for groups and user_permissions
     # to avoid clashes with the default auth.User model.


### PR DESCRIPTION
## Summary
- add `is_active` field with default False to the custom User model
- create migration to alter `is_active`

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855dd1a5a58832088e48e83c92bfaa0