### PR TITLE
Fix banner links to product pages

### DIFF
--- a/frontend/src/components/Home/Hero/HeroCarousel.tsx
+++ b/frontend/src/components/Home/Hero/HeroCarousel.tsx
@@ -34,14 +34,20 @@ const HeroCarousal = () => {
     .map((s) => {
       const p = s.product_details;
       const imgSrc = getProductImage(p);
-      if (!imgSrc) return null;
+      if (!imgSrc || !p?.slug) return null;
       return {
-        title: p?.name || "",
+        title: p.name,
         image: imgSrc,
-        discount: p?.get_discount_percentage || 0,
+        discount: p.get_discount_percentage || 0,
+        slug: p.slug,
       };
     })
-    .filter(Boolean) as { title: string; image: string; discount: number }[];
+    .filter(Boolean) as {
+      title: string;
+      image: string;
+      discount: number;
+      slug: string;
+    }[];
 
 
   return (
@@ -66,7 +72,7 @@ const HeroCarousal = () => {
               </h2>
               <p className="text-dark-base mb-6">Limited time deal on our best price.</p>
               <Link
-                href="/shop"
+                href={`/shop-details/${encodeURIComponent(item.slug)}`}
                 className="inline-block bg-accent text-white py-3 px-9 rounded-md hover:bg-[#b88d4f] transition"
               >
                 Shop Now

--- a/frontend/src/components/Home/PromoBanner/index.tsx
+++ b/frontend/src/components/Home/PromoBanner/index.tsx
@@ -38,7 +38,7 @@ const PromoBanner = () => {
               </h2>
 
               <Link
-                href={`/product/${big.product_details?.slug}`}
+                href={`/shop-details/${encodeURIComponent(big.product_details?.slug || '')}`}
                 className="inline-flex font-medium text-custom-sm text-white bg-blue py-[11px] px-9.5 rounded-md ease-out duration-200 hover:bg-blue-dark mt-7.5"
               >
                 Buy Now
@@ -83,7 +83,7 @@ const PromoBanner = () => {
                 </h2>
 
                 <Link
-                  href={`/product/${banner.product_details?.slug}`}
+                  href={`/shop-details/${encodeURIComponent(banner.product_details?.slug || '')}`}
                   className={`inline-flex font-medium text-custom-sm text-white ${idx === 0 ? 'bg-teal hover:bg-teal-dark' : 'bg-orange hover:bg-orange-dark'} py-2.5 px-8.5 rounded-md ease-out duration-200 mt-7.5`}
                 >
                   Shop Now


### PR DESCRIPTION
## Summary
- route promo banner buttons to product detail pages
- update hero carousel to point slides directly at the product pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561b7e68108320a46b7647304efa07